### PR TITLE
fix(chess): render castling on the king's destination

### DIFF
--- a/libs/chess/__tests__/legal-destinations.test.ts
+++ b/libs/chess/__tests__/legal-destinations.test.ts
@@ -22,6 +22,9 @@ const START = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 const sanSquares = (fen: string, san: string) =>
   squaresOfSan(positionFromFen(fen).unwrap(), san);
 
+/** Same position with the other side to move. */
+const blackToMove = (fen: string) => fen.replace(" w ", " b ");
+
 const at = (fen: string, square: string) =>
   legalDestinations(positionFromFen(fen).unwrap(), square);
 
@@ -117,6 +120,24 @@ describe("squaresOfSan", () => {
   it("names the squares a played move touched", () => {
     expect(sanSquares(START, "e4")).toEqual({ from: "e2", to: "e4" });
     expect(sanSquares(START, "Nf3")).toEqual({ from: "g1", to: "f3" });
+  });
+
+  it("renders castling on the king's destination, not the rook's square", () => {
+    // chessops encodes castling as the king taking its own rook (e1h1);
+    // a board drawing the move wants the square the king lands on — which
+    // is also what an engine's UCI would name (issue #3).
+    const castling = "r3k2r/ppp2ppp/8/8/8/8/PPP2PPP/R3K2R w KQkq - 0 1";
+
+    expect(sanSquares(castling, "O-O")).toEqual({ from: "e1", to: "g1" });
+    expect(sanSquares(castling, "O-O-O")).toEqual({ from: "e1", to: "c1" });
+    expect(sanSquares(blackToMove(castling), "O-O")).toEqual({
+      from: "e8",
+      to: "g8",
+    });
+    expect(sanSquares(blackToMove(castling), "O-O-O")).toEqual({
+      from: "e8",
+      to: "c8",
+    });
   });
 
   it("gives nothing when the move does not fit the position", () => {

--- a/libs/chess/moves.ts
+++ b/libs/chess/moves.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Context, Position } from "chessops/chess";
-import { normalizeMove } from "chessops/chess";
+import { castlingSide, normalizeMove } from "chessops/chess";
 import { SquareSet } from "chessops/squareSet";
 import {
   type DropMove,
@@ -140,9 +140,22 @@ export function squaresOfUci(uci: string): MoveSquares | null {
 /**
  * Squares a SAN move touches; requires the position since SAN leaves the
  * origin implicit (e.g. which knight `Nf3` means depends on the board).
+ * Castling comes back as the king's own two-square step (O-O → g1), not the
+ * king-takes-own-rook encoding chessops uses internally — drawing wants the
+ * square the king lands on, which is also what an engine's UCI would name.
  */
 export function squaresOfSan(pos: Position, san: string): MoveSquares | null {
   const move = parseSan(pos, san);
   if (!move || !isNormal(move)) return null;
+
+  const side = castlingSide(pos, move);
+  if (side) {
+    const kingFile = side === "h" ? 6 : 2; // g-file or c-file, zero-based
+    return {
+      from: makeSquare(move.from),
+      to: makeSquare(kingFile + 8 * (move.to >> 3)),
+    };
+  }
+
   return { from: makeSquare(move.from), to: makeSquare(move.to) };
 }


### PR DESCRIPTION
Closes #3

Problem:
- After castling, the move annotation badge landed on the rook's original square (h1/a1/h8/a8) instead of the king's destination (g1/c1/g8/c8).

Solution:
- chessops encodes castling as king-takes-own-rook (O-O → `e1h1`), and `squaresOfSan` passed that square through to every drawing call site. The fix translates castling moves to the king's two-square step inside `squaresOfSan` — the single source the badge, last-move highlight and arrows all read from, so one change covers every renderer (game replay, drill verdict marks, repertoire practice).
- `legalDestinations`/`legalMoveBetween` keep the rook square on purpose: drag normalisation depends on it (existing test documents that).

Result:
- Reproduced first: `squaresOfSan(pos, "O-O")` returned `{from: e1, to: h1}`; now returns `{from: e1, to: g1}` (and c1/g8/c8 for the other three cases).
- New test covers all four castling directions, both colours.
- Full gates green: `pnpm typecheck`, `vitest --project chess` (52 passed), `vitest --project web` (273 passed), lint, fmt:check, knip.
