### PR TITLE
feat: fetch provider avatar and flair at connect time

### DIFF
--- a/apps/server/__tests__/profile-identity.test.ts
+++ b/apps/server/__tests__/profile-identity.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+/**
+ * Provider profile identity over the real route: an avatar read off
+ * Chess.com and a flair read off Lichess land in the tracked account,
+ * survive listing, and never cost a connection when the provider's
+ * profile endpoint is down.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { LICHESS_PGN_EXPORT } from "@velachess/fixtures";
+import { chessComFixtureFetch } from "@velachess/test-utils";
+
+import { createApiHarness, type ApiHarness, type AuthedApp } from "./harness.ts";
+
+const CHESS_COM_AVATAR =
+  "https://images.chesscomfiles.com/uploads/v1/user/461825478.97ae265f.200x200o.5fa38b32b080.jpg";
+const LICHESS_FLAIR = "people.santa-claus-light-skin-tone";
+
+/**
+ * The suite's chess.com fixtures, plus the two profile endpoints the
+ * connect slice now reads. `setProfilesUp(false)` blackholes them —
+ * the failure mode every test below leans on.
+ */
+function fakeSyncFetch() {
+  const base = chessComFixtureFetch();
+  let profilesUp = true;
+
+  const doFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (CHESS_COM_PROFILE_URL.test(url)) {
+      if (!profilesUp) return new Response("not found", { status: 404 });
+      return Response.json({
+        username: url.split("/").pop(),
+        avatar: CHESS_COM_AVATAR,
+        country: "https://api.chess.com/pub/country/BR",
+      });
+    }
+    if (url.startsWith("https://lichess.org/api/user/")) {
+      if (!profilesUp) return new Response("not found", { status: 404 });
+      return Response.json({
+        id: "sea-lion",
+        username: "Sea-Lion",
+        flair: LICHESS_FLAIR,
+      });
+    }
+    if (url.startsWith("https://lichess.org/api/games/user/")) {
+      return new Response(LICHESS_PGN_EXPORT, {
+        headers: { "content-type": "application/x-chess-pgn" },
+      });
+    }
+    return base(input, init);
+  }) as typeof globalThis.fetch;
+
+  return { fetch: doFetch, setProfilesUp: (up: boolean) => void (profilesUp = up) };
+}
+
+const json = (body: unknown): RequestInit => ({
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+/** Exactly `/pub/player/{name}` — the archives index lives one segment
+ * deeper (`/pub/player/{name}/games/archives`) and must fall through. */
+const CHESS_COM_PROFILE_URL = /^https:\/\/api\.chess\.com\/pub\/player\/[^/]+$/;
+
+const sync = fakeSyncFetch();
+
+let harness: ApiHarness;
+let owner: AuthedApp;
+
+beforeAll(async () => {
+  harness = await createApiHarness({ fetch: sync.fetch });
+  owner = (await harness.signUp("identity@api.test")).app;
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+interface AccountView {
+  id: string;
+  platform: string;
+  username: string;
+  avatarUrl: string | null;
+  flair: string | null;
+}
+
+async function listAccounts(): Promise<AccountView[]> {
+  return (await (await owner.request("/accounts")).json()) as AccountView[];
+}
+
+describe("provider profile identity", () => {
+  it("a chess.com import stores the avatar the provider reports", async () => {
+    const created = await owner.request(
+      "/accounts",
+      json({ platform: "chess_com", username: "Looper" }),
+    );
+    expect(created.status).toBe(201);
+    const account = (await created.json()) as AccountView;
+    expect(account.username).toBe("looper");
+    expect(account.avatarUrl).toBe(CHESS_COM_AVATAR);
+    // Chess.com has no flair concept — the field exists and stays empty.
+    expect(account.flair).toBeNull();
+
+    const listed = await listAccounts();
+    expect(listed.find((entry) => entry.id === account.id)?.avatarUrl).toBe(
+      CHESS_COM_AVATAR,
+    );
+  });
+
+  it("a lichess import stores the flair, and never an avatar", async () => {
+    const created = await owner.request(
+      "/accounts",
+      json({ platform: "lichess", username: "Sea-Lion" }),
+    );
+    expect(created.status).toBe(201);
+    const account = (await created.json()) as AccountView;
+    // Flair decorates the name; it is not a face, so avatar stays null
+    // even though the connection succeeded.
+    expect(account.flair).toBe(LICHESS_FLAIR);
+    expect(account.avatarUrl).toBeNull();
+
+    const listed = await listAccounts();
+    expect(listed.find((entry) => entry.id === account.id)?.flair).toBe(LICHESS_FLAIR);
+  });
+
+  it("a re-import that cannot reach the profile keeps the identity already stored", async () => {
+    // First import reads the avatar…
+    await owner.request("/accounts", json({ platform: "chess_com", username: "looper" }));
+    // …then the provider's profile endpoint goes down and the handle is
+    // imported again (the documented way to refresh a connection).
+    sync.setProfilesUp(false);
+    try {
+      const again = await owner.request(
+        "/accounts",
+        json({ platform: "chess_com", username: "looper" }),
+      );
+      expect(again.status).toBe(201);
+      expect(((await again.json()) as AccountView).avatarUrl).toBe(CHESS_COM_AVATAR);
+    } finally {
+      sync.setProfilesUp(true);
+    }
+  });
+
+  it("a dead profile endpoint costs the decoration, not the connection", async () => {
+    sync.setProfilesUp(false);
+    try {
+      const created = await owner.request(
+        "/accounts",
+        json({ platform: "lichess", username: "sea-wolf" }),
+      );
+      expect(created.status).toBe(201);
+      const account = (await created.json()) as AccountView;
+      expect(account.avatarUrl).toBeNull();
+      expect(account.flair).toBeNull();
+
+      // The archive was filled regardless — the account works.
+      const games = await owner.request(`/accounts/${account.id}/games`);
+      expect(games.status).toBe(200);
+    } finally {
+      sync.setProfilesUp(true);
+    }
+  });
+});

--- a/apps/server/src/openapi.ts
+++ b/apps/server/src/openapi.ts
@@ -99,6 +99,18 @@ export const openApiSpec = {
                   id: { type: "string", format: "uuid" },
                   platform: { type: "string", enum: ["chess_com", "lichess"] },
                   username: { type: "string" },
+                  avatarUrl: {
+                    type: "string",
+                    nullable: true,
+                    description:
+                      "Chess.com profile picture, read at connect time; null when the account has none or is on Lichess, which has no avatars",
+                  },
+                  flair: {
+                    type: "string",
+                    nullable: true,
+                    description:
+                      "Lichess flair asset id (e.g. people.santa-claus), read at connect time; null when unset or on Chess.com",
+                  },
                   lastSyncedAt: { type: "string", format: "date-time", nullable: true },
                   syncState: {
                     type: "string",
@@ -106,7 +118,15 @@ export const openApiSpec = {
                     description: "Delivery state of the newest non-completed sync job",
                   },
                 },
-                required: ["id", "platform", "username", "lastSyncedAt", "syncState"],
+                required: [
+                  "id",
+                  "platform",
+                  "username",
+                  "avatarUrl",
+                  "flair",
+                  "lastSyncedAt",
+                  "syncState",
+                ],
               },
             }),
           },
@@ -134,8 +154,10 @@ export const openApiSpec = {
                 id: { type: "string", format: "uuid" },
                 platform: { type: "string" },
                 username: { type: "string" },
+                avatarUrl: { type: "string", nullable: true },
+                flair: { type: "string", nullable: true },
               },
-              required: ["id", "platform", "username"],
+              required: ["id", "platform", "username", "avatarUrl", "flair"],
             }),
           },
           "400": { description: "Invalid body", ...errorResponse },

--- a/apps/server/src/routes/accounts.ts
+++ b/apps/server/src/routes/accounts.ts
@@ -41,7 +41,13 @@ export function accountsRoutes(deps: ApiDeps) {
           deps.sync ?? {},
         );
         return c.json(
-          { id: account.id, platform: account.platform, username: account.username },
+          {
+            id: account.id,
+            platform: account.platform,
+            username: account.username,
+            avatarUrl: account.avatarUrl,
+            flair: account.flair,
+          },
           201,
         );
       })

--- a/apps/web/src/games/__tests__/analysis-read.test.ts
+++ b/apps/web/src/games/__tests__/analysis-read.test.ts
@@ -4,6 +4,7 @@ import { aGradedPly } from "../../test/games.ts";
 import {
   suggestedArrow,
   previewFor,
+  seatIdentityOf,
   seatOf,
   badgeForCategory,
   bestMoveSan,
@@ -303,6 +304,57 @@ describe("seatOf", () => {
     // has no seat of yours to take.
     expect(seatOf(game, ["someoneelse"])).toBe("white");
     expect(seatOf(game, [])).toBe("white");
+  });
+});
+
+/**
+ * Which seats carry provider identity.
+ *
+ * Profiles exist only for handles this user tracks, and a handle is
+ * platform-scoped: the same name on both platforms may show two
+ * different pictures.
+ */
+describe("seatIdentityOf", () => {
+  const tracked = [
+    {
+      platform: "chess_com",
+      username: "yurimutti",
+      avatarUrl: "https://example.com/pic.jpg",
+      flair: null,
+    },
+    {
+      platform: "lichess",
+      username: "yurimutti",
+      avatarUrl: null,
+      flair: "people.santa-claus-light-skin-tone",
+    },
+  ];
+
+  it("returns the identity of the handle on that game's platform", () => {
+    expect(seatIdentityOf("chess_com", "yurimutti", tracked)).toEqual({
+      avatarUrl: "https://example.com/pic.jpg",
+    });
+    expect(seatIdentityOf("lichess", "yurimutti", tracked)).toEqual({
+      flair: "people.santa-claus-light-skin-tone",
+    });
+  });
+
+  it("matches a username whatever its case", () => {
+    // Platforms echo back whatever casing the player typed — the same
+    // rule `seatOf` applies when finding your side of the board.
+    expect(seatIdentityOf("chess_com", "YuriMutti", tracked)).toEqual({
+      avatarUrl: "https://example.com/pic.jpg",
+    });
+  });
+
+  it("answers nothing for a handle this user does not track", () => {
+    expect(seatIdentityOf("chess_com", "gothamchess", tracked)).toEqual({});
+    expect(seatIdentityOf("lichess", "yurimutti", [])).toEqual({});
+  });
+
+  it("answers nothing for a source that has no accounts at all", () => {
+    // A pasted PGN is not any platform's handle, whoever plays it.
+    expect(seatIdentityOf("pgn", "yurimutti", tracked)).toEqual({});
   });
 });
 

--- a/apps/web/src/games/analysis-read.ts
+++ b/apps/web/src/games/analysis-read.ts
@@ -186,6 +186,45 @@ export function seatOf(
   return "white";
 }
 
+export interface SeatIdentity {
+  /** Provider profile picture, read at connect time. Absent when the
+   * handle has none — initials stand in. */
+  avatarUrl?: string;
+  /** Lichess asset id, decorated beside the name. Never an avatar. */
+  flair?: string;
+}
+
+/**
+ * The provider identity of one seat, when that handle is one this user
+ * tracks — profiles exist only for connected accounts, so an opponent's
+ * seat stays on initials unless their handle was imported too.
+ *
+ * Platform and username together, case-insensitively: the same handle on
+ * both platforms may carry two different pictures.
+ */
+export function seatIdentityOf(
+  source: string,
+  name: string,
+  tracked: readonly {
+    platform: string;
+    username: string;
+    avatarUrl: string | null;
+    flair: string | null;
+  }[],
+): SeatIdentity {
+  const handle = tracked.find(
+    (account) =>
+      account.platform === source &&
+      account.username.toLowerCase() === name.toLowerCase(),
+  );
+  if (!handle) return {};
+
+  return {
+    ...(handle.avatarUrl !== null ? { avatarUrl: handle.avatarUrl } : {}),
+    ...(handle.flair !== null ? { flair: handle.flair } : {}),
+  };
+}
+
 /** Engine's move as an arrow, not a played position — keeps the board showing the choice the player faced. */
 export function suggestedArrow(
   fen: string | undefined,

--- a/apps/web/src/games/import/queries.ts
+++ b/apps/web/src/games/import/queries.ts
@@ -16,12 +16,13 @@ import { INPUT_KINDS, type SourceId } from "./sources.ts";
 export type TrackedAccount = InferResponseType<typeof api.accounts.$get, 200>[number];
 
 /** Lichess serves its flairs from one public asset directory keyed by the
- * id the API reports (`people.santa-claus` → `<dir>/people.santa-claus.svg`).
- * Only the id crosses the API; the address is presentation. */
+ * id the API reports (`people.santa-claus` → `<dir>/people.santa-claus.webp`),
+ * rendered as webp by its own frontend. Only the id crosses the API; the
+ * address is presentation. */
 const LICHESS_FLAIR_ASSETS = "https://lichess1.org/assets/flair/img";
 
 export function flairImageOf(flair: string): string {
-  return `${LICHESS_FLAIR_ASSETS}/${flair}.svg`;
+  return `${LICHESS_FLAIR_ASSETS}/${flair}.webp`;
 }
 
 /** Tracked accounts per the server, not localStorage's `my-accounts` — a new machine or rebuilt DB can desync from local memory. */

--- a/apps/web/src/games/import/queries.ts
+++ b/apps/web/src/games/import/queries.ts
@@ -15,6 +15,15 @@ import { INPUT_KINDS, type SourceId } from "./sources.ts";
 
 export type TrackedAccount = InferResponseType<typeof api.accounts.$get, 200>[number];
 
+/** Lichess serves its flairs from one public asset directory keyed by the
+ * id the API reports (`people.santa-claus` → `<dir>/people.santa-claus.svg`).
+ * Only the id crosses the API; the address is presentation. */
+const LICHESS_FLAIR_ASSETS = "https://lichess1.org/assets/flair/img";
+
+export function flairImageOf(flair: string): string {
+  return `${LICHESS_FLAIR_ASSETS}/${flair}.svg`;
+}
+
 /** Tracked accounts per the server, not localStorage's `my-accounts` — a new machine or rebuilt DB can desync from local memory. */
 export const trackedAccountsQuery = queryOptions({
   queryKey: ["accounts"],

--- a/apps/web/src/games/open-game/__tests__/game-analysis.test.tsx
+++ b/apps/web/src/games/open-game/__tests__/game-analysis.test.tsx
@@ -347,7 +347,7 @@ describe("provider identity on the board", () => {
 
     expect(sources).toEqual([
       MY_AVATAR,
-      `https://lichess1.org/assets/flair/img/${MY_FLAIR}.svg`,
+      `https://lichess1.org/assets/flair/img/${MY_FLAIR}.webp`,
     ]);
   });
 

--- a/apps/web/src/games/open-game/__tests__/game-analysis.test.tsx
+++ b/apps/web/src/games/open-game/__tests__/game-analysis.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { beforeEach, afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -359,6 +359,20 @@ describe("provider identity on the board", () => {
     // connected, so their seat has no picture to show.
     const opponent = within(board).getByText("gothamchess").closest("div")!;
     expect(opponent.querySelectorAll("img")).toHaveLength(0);
+  });
+
+  it("hides the flair when its asset fails to load", async () => {
+    // An asset that 404s must not leave a broken-image glyph where the
+    // decoration stood.
+    await openGame({ kind: "cached", moves: gradedPlies() });
+
+    const board = await screen.findByRole("region", { name: "Board" });
+    const strip = within(board).getByText(ME).closest("div")!;
+    const flair = [...strip.querySelectorAll("img")].at(-1)!;
+
+    fireEvent(flair, new Event("error"));
+
+    expect(flair).not.toBeVisible();
   });
 });
 

--- a/apps/web/src/games/open-game/__tests__/game-analysis.test.tsx
+++ b/apps/web/src/games/open-game/__tests__/game-analysis.test.tsx
@@ -1,6 +1,6 @@
 import { screen, within } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
   addGames,
@@ -300,6 +300,65 @@ describe("game analysis", () => {
 
     expect(await screen.findByText("Couldn't load analysis.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Try again" })).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Provider identity reaches the board: a handle this user tracks shows
+ * the picture and flair its platform reported, everyone else stays on
+ * initials.
+ */
+describe("provider identity on the board", () => {
+  const MY_AVATAR = "https://images.chesscomfiles.com/uploads/v1/user/461825478.test.jpg";
+  const MY_FLAIR = "people.santa-claus-light-skin-tone";
+
+  beforeAll(() => {
+    // jsdom loads no resources, so base-ui's Avatar waits forever on a
+    // preload that never fires and mounts no <img>. A loaded picture is
+    // what a real browser reports; make jsdom say the same.
+    vi.stubGlobal(
+      "Image",
+      class {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        complete = true;
+        naturalWidth = 64;
+      },
+    );
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    deviceHasImported({ avatarUrl: MY_AVATAR, flair: MY_FLAIR });
+  });
+
+  it("shows the tracked handle's avatar and flair beside the name", async () => {
+    await openGame({ kind: "cached", moves: gradedPlies() });
+
+    const board = await screen.findByRole("region", { name: "Board" });
+    // White by default — my strip sits at the bottom of the board region.
+    const strip = within(board).getByText(ME).closest("div")!;
+    const sources = [...strip.querySelectorAll("img")].map((image) =>
+      image.getAttribute("src"),
+    );
+
+    expect(sources).toEqual([
+      MY_AVATAR,
+      `https://lichess1.org/assets/flair/img/${MY_FLAIR}.svg`,
+    ]);
+  });
+
+  it("leaves an untracked opponent on initials alone", async () => {
+    await openGame({ kind: "cached", moves: gradedPlies() });
+
+    const board = await screen.findByRole("region", { name: "Board" });
+    // Only the imported handle carries identity; gothamchess was never
+    // connected, so their seat has no picture to show.
+    const opponent = within(board).getByText("gothamchess").closest("div")!;
+    expect(opponent.querySelectorAll("img")).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/games/open-game/board-pane.tsx
+++ b/apps/web/src/games/open-game/board-pane.tsx
@@ -39,6 +39,9 @@ interface PlayerSeat {
   name: string;
   /** Already localised — absent when the platform did not report one. */
   rating: string | undefined;
+  /** Provider identity of a tracked handle; absent for everyone else. */
+  avatarUrl: string | undefined;
+  flair: string | undefined;
 }
 
 export interface BoardPaneProps {
@@ -89,6 +92,8 @@ export function BoardPane({
       <PlayerStrip
         name={top.name}
         rating={top.rating}
+        avatarSrc={top.avatarUrl}
+        flairSrc={top.flair}
         className={cn(STRIP_INSET, BOARD_WIDTH)}
       />
 
@@ -118,6 +123,8 @@ export function BoardPane({
       <PlayerStrip
         name={bottom.name}
         rating={bottom.rating}
+        avatarSrc={bottom.avatarUrl}
+        flairSrc={bottom.flair}
         className={cn(STRIP_INSET, BOARD_WIDTH)}
       />
 

--- a/apps/web/src/games/open-game/game-analysis.tsx
+++ b/apps/web/src/games/open-game/game-analysis.tsx
@@ -11,10 +11,18 @@ import { cn } from "@velachess/ui/lib/utils";
 
 import { BoardScreen } from "../../app-shell/board-screen.tsx";
 import { useMyAccounts } from "../import/my-accounts.ts";
-import { gradeAtPly, previewFor, seatOf, suggestedArrow } from "../analysis-read.ts";
+import { flairImageOf, trackedAccountsQuery } from "../import/queries.ts";
+import {
+  gradeAtPly,
+  previewFor,
+  seatIdentityOf,
+  seatOf,
+  suggestedArrow,
+} from "../analysis-read.ts";
 import { BoardPane } from "./board-pane.tsx";
 import { AnalysisPanel } from "./analysis-panel.tsx";
 import { useAnalysis } from "../watch-analysis/use-analysis.ts";
+import { useQuery } from "../../shared/libs/query/index.ts";
 
 const ANALYSE_COPY = {
   loading: msg`Loading the game…`,
@@ -45,6 +53,9 @@ function GameAnalysisContent({ gameId }: { gameId: string }) {
   // new array every render never compares equal, and zustand re-renders
   // until React gives up.
   const myAccounts = useMyAccounts((state) => state.accounts);
+  // Provider identity for the seats — only handles this user tracks have
+  // one, so an opponent's seat stays on initials unless imported too.
+  const tracked = useQuery(trackedAccountsQuery).data ?? [];
   /**
    * The engine's move, shown on the board.
    *
@@ -87,10 +98,17 @@ function GameAnalysisContent({ gameId }: { gameId: string }) {
     );
   }
 
-  const seat = (name: string, rating: number | null) => ({
-    name,
-    rating: rating === null ? undefined : i18n.number(rating),
-  });
+  const seat = (name: string, rating: number | null) => {
+    const identity = seatIdentityOf(game.source, name, tracked);
+    return {
+      name,
+      rating: rating === null ? undefined : i18n.number(rating),
+      avatarUrl: identity.avatarUrl,
+      // The API carries the flair id; the address it is served from is
+      // presentation, resolved at the last moment before render.
+      flair: identity.flair ? flairImageOf(identity.flair) : undefined,
+    };
+  };
   const white = seat(game.whiteName, game.whiteRating);
   const black = seat(game.blackName, game.blackRating);
 

--- a/apps/web/src/onboarding/__tests__/dashboard-state.test.ts
+++ b/apps/web/src/onboarding/__tests__/dashboard-state.test.ts
@@ -9,6 +9,8 @@ const account = (syncState: "none" | "queued" | "active" | "failed") => ({
   id: "account-1",
   platform: "chess_com" as const,
   username: "looper",
+  avatarUrl: null,
+  flair: null,
   lastSyncedAt: null,
   syncState,
 });

--- a/apps/web/src/test/archive.ts
+++ b/apps/web/src/test/archive.ts
@@ -10,6 +10,9 @@ export interface ArchiveAccount {
   id: string;
   platform: Platform;
   username: string;
+  /** Provider identity, as the real route returns it. */
+  avatarUrl: string | null;
+  flair: string | null;
   lastSyncedAt: string | null;
 }
 
@@ -17,6 +20,8 @@ const DEFAULT_ACCOUNT: ArchiveAccount = {
   id: "account-1",
   platform: "chess_com",
   username: ME,
+  avatarUrl: null,
+  flair: null,
   lastSyncedAt: "2026-05-04T18:30:00.000Z",
 };
 

--- a/apps/web/src/test/device.ts
+++ b/apps/web/src/test/device.ts
@@ -9,14 +9,20 @@ export function resetDevice(): void {
   useSourceStore.setState(useSourceStore.getInitialState(), true);
 }
 
-/** Puts the device in the post-import state so `_app` lets it through, without routing every test through the import form. */
-export function deviceHasImported(): RememberedAccount {
+/** Puts the device in the post-import state so `_app` lets it through, without routing every test through the import form. Identity defaults to none — pass it to simulate a provider that reported one at connect time. */
+export function deviceHasImported(
+  identity: { avatarUrl: string | null; flair: string | null } = {
+    avatarUrl: null,
+    flair: null,
+  },
+): RememberedAccount {
   const account = archiveAccount();
   // The server's side of the same fact — the dashboard asks it, not the device.
   accountIsTracked({
     id: account.id,
     platform: account.platform,
     username: account.username,
+    ...identity,
   });
   const remembered: RememberedAccount = {
     accountId: account.id,

--- a/apps/web/src/test/handlers/accounts.ts
+++ b/apps/web/src/test/handlers/accounts.ts
@@ -8,6 +8,10 @@ interface TrackedAccountRow {
   id: string;
   platform: "chess_com" | "lichess";
   username: string;
+  /** Provider identity, per the real route: read at connect time, null
+   * when the account has none or the provider never reported one. */
+  avatarUrl: string | null;
+  flair: string | null;
   lastSyncedAt: string | null;
   syncState: QueueState;
 }
@@ -26,6 +30,8 @@ export function accountIsTracked(
       id: account.id ?? `account-${trackedAccounts.length + 1}`,
       platform: account.platform ?? "chess_com",
       username: account.username,
+      avatarUrl: account.avatarUrl ?? null,
+      flair: account.flair ?? null,
       lastSyncedAt: account.lastSyncedAt ?? null,
       syncState: account.syncState ?? "none",
     },
@@ -57,11 +63,19 @@ export const accountsHandlers = [
         id: account.id,
         platform: account.platform,
         username: account.username,
+        avatarUrl: account.avatarUrl,
+        flair: account.flair,
         lastSyncedAt: account.lastSyncedAt,
       });
     }
     return HttpResponse.json(
-      { id: account.id, platform: account.platform, username: account.username },
+      {
+        id: account.id,
+        platform: account.platform,
+        username: account.username,
+        avatarUrl: account.avatarUrl,
+        flair: account.flair,
+      },
       { status: 201 },
     );
   }),

--- a/libs/application/__tests__/application.test.ts
+++ b/libs/application/__tests__/application.test.ts
@@ -431,12 +431,19 @@ describe("application services (the flow, end to end)", () => {
       expect(game.analyzed).toBe(false);
     }
 
-    // Second read never touches the platform: a fetch that would throw.
+    // Second read never pulls the archive again: a fetch that would throw
+    // on any game request. The profile endpoint is answered instead of
+    // throwing — a re-import still refreshes identity by design — and
+    // returning no avatar keeps what was stored.
     const again = await openImported(
       "fresh_import",
       {},
       {
-        fetch: (() => {
+        fetch: (async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (/\/pub\/player\/[^/]+$/.test(url)) {
+            return Response.json({ username: "fresh_import" });
+          }
           throw new Error("the archive was already filled");
         }) as unknown as typeof fetch,
       },

--- a/libs/application/accounts/connect-account/connect-account.ts
+++ b/libs/application/accounts/connect-account/connect-account.ts
@@ -7,12 +7,34 @@
  */
 import type { Database } from "@velachess/db";
 import { getTrackedAccount, upsertTrackedAccount } from "@velachess/db";
+import type { FetchFn } from "@velachess/platforms";
+import { fetchChessComProfile, fetchLichessProfile } from "@velachess/platforms";
 
 import { ensureCandidateRepertoires } from "../../repertoires/extract-repertoire/extract-repertoire.ts";
 import type { SyncDeps } from "../sync-account/sync-account.ts";
 import { syncAccount } from "../sync-account/sync-account.ts";
 
 export type Platform = "chess_com" | "lichess";
+
+/**
+ * Read the provider's picture of this handle, once, at the moment the
+ * connection is made — profiles change rarely and games every session,
+ * so a refresh cadence of their own would spend requests on nothing.
+ *
+ * The read is decoration around the name and fails soft by contract
+ * (the fetchers answer an empty profile rather than throw), so a provider
+ * outage costs the avatar, never the connection.
+ */
+async function fetchProfile(
+  platform: Platform,
+  username: string,
+  deps: SyncDeps,
+): Promise<{ avatarUrl: string | null; flair: string | null }> {
+  const opts = deps.fetch ? { fetch: deps.fetch as FetchFn } : {};
+  return platform === "chess_com"
+    ? await fetchChessComProfile(username, opts)
+    : await fetchLichessProfile(username, opts);
+}
 
 /**
  * Start tracking a handle: create (or find) the user's connection to it,
@@ -35,7 +57,10 @@ export async function importAccount(
   username: string,
   deps: SyncDeps = {},
 ) {
-  const tracked = await upsertTrackedAccount(db, userId, platform, username);
+  // Before the upsert, so the row is born with its identity and a
+  // re-import refreshes it in the same write that finds the connection.
+  const profile = await fetchProfile(platform, username, deps);
+  const tracked = await upsertTrackedAccount(db, userId, platform, username, profile);
   if (tracked.lastSyncedAt === null) {
     const outcome = await syncAccount(db, tracked.id, deps);
     // The first archive is also the first chance to derive a book, and

--- a/libs/application/accounts/connect-account/connect-account.ts
+++ b/libs/application/accounts/connect-account/connect-account.ts
@@ -7,7 +7,6 @@
  */
 import type { Database } from "@velachess/db";
 import { getTrackedAccount, upsertTrackedAccount } from "@velachess/db";
-import type { FetchFn } from "@velachess/platforms";
 import { fetchChessComProfile, fetchLichessProfile } from "@velachess/platforms";
 
 import { ensureCandidateRepertoires } from "../../repertoires/extract-repertoire/extract-repertoire.ts";
@@ -25,15 +24,11 @@ export type Platform = "chess_com" | "lichess";
  * (the fetchers answer an empty profile rather than throw), so a provider
  * outage costs the avatar, never the connection.
  */
-async function fetchProfile(
-  platform: Platform,
-  username: string,
-  deps: SyncDeps,
-): Promise<{ avatarUrl: string | null; flair: string | null }> {
-  const opts = deps.fetch ? { fetch: deps.fetch as FetchFn } : {};
+function fetchProfile(platform: Platform, username: string, deps: SyncDeps) {
+  const opts = deps.fetch ? { fetch: deps.fetch } : {};
   return platform === "chess_com"
-    ? await fetchChessComProfile(username, opts)
-    : await fetchLichessProfile(username, opts);
+    ? fetchChessComProfile(username, opts)
+    : fetchLichessProfile(username, opts);
 }
 
 /**

--- a/libs/application/accounts/list-accounts/list-accounts.ts
+++ b/libs/application/accounts/list-accounts/list-accounts.ts
@@ -21,6 +21,8 @@ export async function listTrackedAccountsByUser(db: Database, userId: string) {
       id: trackedAccounts.id,
       platform: trackedAccounts.platform,
       username: trackedAccounts.username,
+      avatarUrl: trackedAccounts.avatarUrl,
+      flair: trackedAccounts.flair,
       lastSyncedAt: trackedAccounts.lastSyncedAt,
     })
     .from(trackedAccounts)

--- a/libs/infra/db/migrations/0015_profile_identity.sql
+++ b/libs/infra/db/migrations/0015_profile_identity.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tracked_accounts" ADD COLUMN "avatar_url" text;--> statement-breakpoint
+ALTER TABLE "tracked_accounts" ADD COLUMN "flair" text;

--- a/libs/infra/db/migrations/meta/0015_snapshot.json
+++ b/libs/infra/db/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1902 @@
+{
+  "id": "2ee2a87c-ba83-4604-9681-d5e5c9471e5e",
+  "prevId": "679130a5-52f1-4730-be61-34a9e5c5c83f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_progress": {
+      "name": "analysis_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_progress_run_index": {
+          "name": "analysis_progress_run_index",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_progress_game_seq": {
+          "name": "analysis_progress_game_seq",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_progress_game_id_games_id_fk": {
+          "name": "analysis_progress_game_id_games_id_fk",
+          "tableFrom": "analysis_progress",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_accounts_user_id": {
+          "name": "auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_accounts_provider_account": {
+          "name": "auth_accounts_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due": {
+          "name": "due",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stability": {
+          "name": "stability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_steps": {
+          "name": "learning_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phase": {
+          "name": "phase",
+          "type": "card_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cards_exercise_id": {
+          "name": "cards_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cards_due": {
+          "name": "cards_due",
+          "columns": [
+            {
+              "expression": "due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cards_exercise_id_exercises_id_fk": {
+          "name": "cards_exercise_id_exercises_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deviations": {
+      "name": "deviations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repertoire_name_snapshot": {
+          "name": "repertoire_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_name_snapshot": {
+          "name": "chapter_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "deviation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_book_plies": {
+          "name": "in_book_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_plies": {
+          "name": "game_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played_san": {
+          "name": "played_san",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cp_loss": {
+          "name": "cp_loss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_category": {
+          "name": "engine_category",
+          "type": "engine_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drillable": {
+          "name": "drillable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deviations_game_repertoire": {
+          "name": "deviations_game_repertoire",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_repertoire_id": {
+          "name": "deviations_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_chapter_id": {
+          "name": "deviations_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deviations_game_id_games_id_fk": {
+          "name": "deviations_game_id_games_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deviations_repertoire_id_repertoires_id_fk": {
+          "name": "deviations_repertoire_id_repertoires_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deviations_chapter_id_repertoire_chapters_id_fk": {
+          "name": "deviations_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_responses": {
+      "name": "training_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "training_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "training_responses_exercise_id": {
+          "name": "training_responses_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_responses_exercise_id_exercises_id_fk": {
+          "name": "training_responses_exercise_id_exercises_id_fk",
+          "tableFrom": "training_responses",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_sources": {
+      "name": "exercise_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "drill_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviation_id": {
+          "name": "deviation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "exercise_sources_deviation": {
+          "name": "exercise_sources_deviation",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"deviation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_ply": {
+          "name": "exercise_sources_ply",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"game_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter": {
+          "name": "exercise_sources_chapter",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"chapter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_deviation_id": {
+          "name": "exercise_sources_deviation_id",
+          "columns": [
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_game_id": {
+          "name": "exercise_sources_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter_id": {
+          "name": "exercise_sources_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_sources_exercise_id_exercises_id_fk": {
+          "name": "exercise_sources_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_deviation_id_deviations_id_fk": {
+          "name": "exercise_sources_deviation_id_deviations_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "deviations",
+          "columnsFrom": ["deviation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_game_id_games_id_fk": {
+          "name": "exercise_sources_game_id_games_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_chapter_id_repertoire_chapters_id_fk": {
+          "name": "exercise_sources_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exercise_sources_origin_shape": {
+          "name": "exercise_sources_origin_shape",
+          "value": "(\"exercise_sources\".\"origin\" = 'repertoire-deviation'\n             AND \"exercise_sources\".\"deviation_id\" IS NOT NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'engine-blunder'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NOT NULL AND \"exercise_sources\".\"ply\" IS NOT NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'repertoire-line'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exercises_user_position": {
+          "name": "exercises_user_position",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_user_id": {
+          "name": "exercises_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_analyses": {
+      "name": "game_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine_version": {
+          "name": "engine_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "positions": {
+          "name": "positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_analyses_game_id": {
+          "name": "game_analyses_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_analyses_game_id_games_id_fk": {
+          "name": "game_analyses_game_id_games_id_fk",
+          "tableFrom": "game_analyses",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "game_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perspective": {
+          "name": "perspective",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "white_name": {
+          "name": "white_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "white_rating": {
+          "name": "white_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_name": {
+          "name": "black_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "black_rating": {
+          "name": "black_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "game_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_initial_seconds": {
+          "name": "time_control_initial_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_increment_seconds": {
+          "name": "time_control_increment_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_raw": {
+          "name": "time_control_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_eco": {
+          "name": "opening_eco",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_name": {
+          "name": "opening_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_url": {
+          "name": "opening_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination": {
+          "name": "termination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_clocks": {
+          "name": "has_clocks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_pgn": {
+          "name": "raw_pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movetext_hash": {
+          "name": "movetext_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "games_source_external_id": {
+          "name": "games_source_external_id",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"games\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_account_played_at": {
+          "name": "games_account_played_at",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_account_id_tracked_accounts_id_fk": {
+          "name": "games_account_id_tracked_accounts_id_fk",
+          "tableFrom": "games",
+          "tableTo": "tracked_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_account_movetext": {
+          "name": "games_account_movetext",
+          "nullsNotDistinct": true,
+          "columns": ["account_id", "movetext_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoire_chapters": {
+      "name": "repertoire_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn": {
+          "name": "pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting_fen": {
+          "name": "starting_fen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoire_chapters_repertoire_id": {
+          "name": "repertoire_chapters_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoire_chapters_repertoire_id_repertoires_id_fk": {
+          "name": "repertoire_chapters_repertoire_id_repertoires_id_fk",
+          "tableFrom": "repertoire_chapters",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repertoire_chapters_repertoire_sort": {
+          "name": "repertoire_chapters_repertoire_sort",
+          "nullsNotDistinct": false,
+          "columns": ["repertoire_id", "sort_order"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoires": {
+      "name": "repertoires",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "repertoire_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoires_user_id": {
+          "name": "repertoires_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoires_user_id_users_id_fk": {
+          "name": "repertoires_user_id_users_id_fk",
+          "tableFrom": "repertoires",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id": {
+          "name": "sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_accounts": {
+      "name": "tracked_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flair": {
+          "name": "flair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_accounts_user_platform_username": {
+          "name": "tracked_accounts_user_platform_username",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_accounts_user_id": {
+          "name": "tracked_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracked_accounts_user_id_users_id_fk": {
+          "name": "tracked_accounts_user_id_users_id_fk",
+          "tableFrom": "tracked_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier": {
+          "name": "verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.card_phase": {
+      "name": "card_phase",
+      "schema": "public",
+      "values": ["new", "learning", "review", "relearning"]
+    },
+    "public.deviation_type": {
+      "name": "deviation_type",
+      "schema": "public",
+      "values": ["deviation", "gap", "book-ended", "completed", "unmatched"]
+    },
+    "public.training_grade": {
+      "name": "training_grade",
+      "schema": "public",
+      "values": ["again", "hard", "good", "easy"]
+    },
+    "public.drill_origin": {
+      "name": "drill_origin",
+      "schema": "public",
+      "values": ["repertoire-deviation", "engine-blunder", "repertoire-line"]
+    },
+    "public.engine_category": {
+      "name": "engine_category",
+      "schema": "public",
+      "values": ["ok", "inaccuracy", "mistake", "blunder"]
+    },
+    "public.game_source": {
+      "name": "game_source",
+      "schema": "public",
+      "values": ["chess_com", "lichess", "pgn"]
+    },
+    "public.perspective": {
+      "name": "perspective",
+      "schema": "public",
+      "values": ["white", "black"]
+    },
+    "public.platform": {
+      "name": "platform",
+      "schema": "public",
+      "values": ["chess_com", "lichess"]
+    },
+    "public.repertoire_source": {
+      "name": "repertoire_source",
+      "schema": "public",
+      "values": ["manual", "extracted"]
+    },
+    "public.game_result": {
+      "name": "game_result",
+      "schema": "public",
+      "values": ["1-0", "0-1", "1/2-1/2", "*"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/migrations/meta/_journal.json
+++ b/libs/infra/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1787164664978,
       "tag": "0014_repertoire_names",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1787494859474,
+      "tag": "0015_profile_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/queries/tracked-accounts.ts
+++ b/libs/infra/db/queries/tracked-accounts.ts
@@ -12,24 +12,38 @@ type Cursor = ChessComCursor | LichessCursor;
  * — so two users tracking the same handle get two rows. Previously
  * platform+username was globally unique with a separate ownership
  * UPDATE, which let an import silently steal another user's archive.
+ *
+ * `profile` rides along when given, but a field the provider did not
+ * return leaves the stored value alone: a refetch that comes back empty
+ * (provider hiccup, avatar removed and re-added tomorrow) must not erase
+ * an identity that was already read. Omitting the key on conflict does
+ * exactly that.
  */
 export async function upsertTrackedAccount(
   db: Database,
   userId: string,
   platform: Platform,
   username: string,
+  profile: { avatarUrl: string | null; flair: string | null } = {
+    avatarUrl: null,
+    flair: null,
+  },
 ) {
   const normalized = username.toLowerCase();
   const [account] = await db
     .insert(trackedAccounts)
-    .values({ userId, platform, username: normalized })
+    .values({ userId, platform, username: normalized, ...profile })
     .onConflictDoUpdate({
       target: [
         trackedAccounts.userId,
         trackedAccounts.platform,
         trackedAccounts.username,
       ],
-      set: { username: normalized },
+      set: {
+        username: normalized,
+        ...(profile.avatarUrl !== null ? { avatarUrl: profile.avatarUrl } : {}),
+        ...(profile.flair !== null ? { flair: profile.flair } : {}),
+      },
     })
     .returning();
 

--- a/libs/infra/db/schema.ts
+++ b/libs/infra/db/schema.ts
@@ -190,6 +190,16 @@ export const trackedAccounts = pgTable(
      * documentation of what can actually land in this column. */
     syncCursor: jsonb("sync_cursor").$type<ChessComCursor | LichessCursor>(),
     lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    /** Provider identity, read at connect time and then left alone:
+     * profiles change rarely and games every session, so re-reading one
+     * per sync would spend a request on nothing. Null until the first
+     * successful read; the UI falls back to initials meanwhile, and a
+     * refetch that comes back empty never erases what is here. */
+    avatarUrl: text("avatar_url"),
+    /** Lichess only — an asset id like `people.santa-claus`, not a URL.
+     * Kept apart from `avatar_url`: it decorates the name, it is not a
+     * face. */
+    flair: text("flair"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/libs/infra/platforms/__tests__/profile.test.ts
+++ b/libs/infra/platforms/__tests__/profile.test.ts
@@ -1,8 +1,11 @@
 /**
  * The payloads below are trimmed copies of real responses, captured with
- * curl on 17/08/2026. Invented fixtures would have missed the two things
- * that actually matter here: that `country` is a link, and that `location`
- * is a different, free-text field that does not agree with it.
+ * curl on 17/08/2026 (Lichess flair re-captured 23/08/2026 off
+ * DrNykterstein, whose santa flair the earlier capture predated).
+ * Invented fixtures would have missed the things that actually matter
+ * here: that `country` is a link, that `location` is a different,
+ * free-text field that does not agree with it, and that `flair` is an
+ * asset id at the top level, not part of `profile`.
  */
 import { describe, expect, it } from "vitest";
 
@@ -41,6 +44,15 @@ const LICHESS_REAL_EMPTY = {
   // No `profile` key at all, and no image field anywhere.
 };
 
+const LICHESS_REAL_FLAIRED = {
+  id: "drnykterstein",
+  username: "DrNykterstein",
+  title: "GM",
+  flair: "people.santa-claus-light-skin-tone",
+  profile: {},
+  url: "https://lichess.org/@/DrNykterstein",
+};
+
 describe("countryCodeFromUrl", () => {
   it("takes the code off the end of the link Chess.com sends", () => {
     expect(countryCodeFromUrl("https://api.chess.com/pub/country/BR")).toBe("BR");
@@ -65,6 +77,8 @@ describe("fetchChessComProfile", () => {
 
     expect(profile.avatarUrl).toBe(CHESS_COM_REAL.avatar);
     expect(profile.countryCode).toBe("BR");
+    // Chess.com has no flair concept — the field stays null for every account.
+    expect(profile.flair).toBeNull();
   });
 
   it("does not mistake `location` for the country", async () => {
@@ -82,7 +96,7 @@ describe("fetchChessComProfile", () => {
       fetch: respondWith({ username: "someone" }),
     });
 
-    expect(profile).toEqual({ avatarUrl: null, countryCode: null });
+    expect(profile).toEqual({ avatarUrl: null, flair: null, countryCode: null });
   });
 
   it("comes back empty rather than throwing on a 404", async () => {
@@ -92,7 +106,7 @@ describe("fetchChessComProfile", () => {
       fetch: respondWith(null, false),
     });
 
-    expect(profile).toEqual({ avatarUrl: null, countryCode: null });
+    expect(profile).toEqual({ avatarUrl: null, flair: null, countryCode: null });
   });
 
   it("does not call out at all for a username that cannot exist", async () => {
@@ -124,6 +138,25 @@ describe("fetchLichessProfile", () => {
     });
 
     expect(profile.countryCode).toBe("BR");
+  });
+
+  it("reads the flair off a real response, where it sits at the top level", async () => {
+    // Captured off DrNykterstein: `flair` is a sibling of `profile`, not
+    // inside it, and it is an asset id rather than an image URL.
+    const profile = await fetchLichessProfile("DrNykterstein", {
+      fetch: respondWith(LICHESS_REAL_FLAIRED),
+    });
+
+    expect(profile.flair).toBe("people.santa-claus-light-skin-tone");
+    expect(profile.avatarUrl).toBeNull();
+  });
+
+  it("comes back without a flair when none is set", async () => {
+    const profile = await fetchLichessProfile("yurimutti", {
+      fetch: respondWith(LICHESS_REAL_EMPTY),
+    });
+
+    expect(profile.flair).toBeNull();
   });
 
   it("ignores a flag that is not a country code", async () => {

--- a/libs/infra/platforms/index.ts
+++ b/libs/infra/platforms/index.ts
@@ -14,3 +14,4 @@ export * from "./opening-family.ts";
 export * from "./providers/chess-com.ts";
 export * from "./providers/lichess.ts";
 export * from "./providers/pgn.ts";
+export * from "./providers/profile.ts";

--- a/libs/infra/platforms/providers/profile.ts
+++ b/libs/infra/platforms/providers/profile.ts
@@ -17,11 +17,20 @@ export interface PlayerProfile {
   /** Absent on Lichess, which has no avatars at all, and on Chess.com
    * accounts that never uploaded one. */
   avatarUrl: string | null;
+  /** Lichess only — a flair id like `people.santa-claus-light-skin-tone`,
+   * rendered from Lichess's own asset set, not an image URL. Kept apart
+   * from the avatar on purpose: it decorates the name, it does not stand
+   * in for a face. Null on Chess.com, which has no flair concept. */
+  flair: string | null;
   /** ISO 3166-1 alpha-2, uppercase. Null when undeclared. */
   countryCode: string | null;
 }
 
-const EMPTY_PROFILE: PlayerProfile = { avatarUrl: null, countryCode: null };
+const EMPTY_PROFILE: PlayerProfile = {
+  avatarUrl: null,
+  flair: null,
+  countryCode: null,
+};
 
 /** Chess.com's `country` field is a link like `.../pub/country/BR` — the
  * last path segment is already the code, no need to resolve the link. */
@@ -43,8 +52,10 @@ const chessComProfileSchema = z.object({
 });
 
 /** Lichess omits `profile` until the person fills it, hence `.optional()`.
- * No avatar field exists on this endpoint for any account. */
+ * `flair` sits at the top level and is equally optional. No avatar field
+ * exists on this endpoint for any account. */
 const lichessProfileSchema = z.object({
+  flair: z.string().optional(),
   profile: z.object({ flag: z.string().optional() }).optional(),
 });
 
@@ -69,6 +80,7 @@ export async function fetchChessComProfile(
 
   return {
     avatarUrl: parsed.data.avatar ?? null,
+    flair: null,
     countryCode: countryCodeFromUrl(parsed.data.country),
   };
 }
@@ -89,6 +101,7 @@ export async function fetchLichessProfile(
     // Lichess has no profile pictures. Not "we don't read it yet" — the
     // endpoint carries no image field for any account.
     avatarUrl: null,
+    flair: parsed.data.flair ?? null,
     countryCode: ISO_ALPHA2.test(flag ?? "") ? flag!.toUpperCase() : null,
   };
 }

--- a/libs/ui/src/chess/player-strip.tsx
+++ b/libs/ui/src/chess/player-strip.tsx
@@ -115,6 +115,11 @@ export function PlayerStrip({
           src={flairSrc}
           alt=""
           aria-hidden
+          // A missing asset must not leave a broken-image glyph where the
+          // decoration stood — it simply goes away.
+          onError={(event) => {
+            event.currentTarget.style.display = "none";
+          }}
           className="size-4 shrink-0 object-contain"
         />
       ) : null}

--- a/libs/ui/src/chess/player-strip.tsx
+++ b/libs/ui/src/chess/player-strip.tsx
@@ -71,7 +71,11 @@ export interface PlayerStripProps {
    * this package has no locale. Absent when the rating is unknown. */
   rating?: string | undefined;
   /** Photo URL. Falls back to initials when absent or failing to load. */
-  avatarSrc?: string;
+  avatarSrc?: string | undefined;
+  /** Decoration beside the name — Lichess calls it a flair. Deliberately
+   * not `avatarSrc`: it never stands in for a face, and when it fails to
+   * load it disappears rather than degrading to initials. */
+  flairSrc?: string | undefined;
   /** ISO 3166-1 alpha-2, as both platforms report it. The name behind it
    * is resolved here, so a caller never carries the two out of step. */
   countryCode?: string;
@@ -82,6 +86,7 @@ export function PlayerStrip({
   name,
   rating,
   avatarSrc,
+  flairSrc,
   countryCode,
   className,
 }: PlayerStripProps) {
@@ -102,6 +107,15 @@ export function PlayerStrip({
           {...(countryName
             ? { role: "img", "aria-label": countryName }
             : { "aria-hidden": true })}
+        />
+      ) : null}
+
+      {flairSrc ? (
+        <img
+          src={flairSrc}
+          alt=""
+          aria-hidden
+          className="size-4 shrink-0 object-contain"
         />
       ) : null}
 


### PR DESCRIPTION
## What

Reuses provider profile identity for connected chess accounts (#1):

- **Chess.com** — the optional `avatar` field from `GET https://api.chess.com/pub/player/{username}`
- **Lichess** — the `flair` field, read through the existing profile flow and shown next to the username as Lichess's own flair asset

Identity shows on the board review screen's player strips, for any seat whose handle this user tracks. Everyone else keeps the initials fallback — the existing VelaChess avatar.

## Why

VelaChess never reused profile identity from the connected providers: every player rendered as initials, even the handles you import and sync yourself.

## How

- Profiles are read **once at connect time** (`POST /accounts`) and stored in two new nullable columns on `tracked_accounts` (`0015_profile_identity`). No per-sync requests: profiles change rarely, and the platform layer already keeps them separate from game fetching.
- A failed or missing profile read is decoration, not identity: the connection still succeeds and the UI falls back to initials.
- A re-import refreshes identity, but an empty refetch never erases what was stored — the upsert only writes fields the provider actually returned.
- Flair stays semantically separate from the avatar (`flairSrc` vs `avatarSrc`, its own column): it decorates the name, it never stands in for a face.
- Seat matching is `platform + username`, case-insensitive — the same handle may carry different pictures on the two platforms.

## Verification

**Automated** (`pnpm test`, all projects green):

- platform: real-shape fixtures for chess.com avatar/country and Lichess flair
- backend HTTP seam: avatar stored and listed; lichess flair with `avatarUrl: null`; dead profile endpoint still connects; re-import under outage keeps stored identity
- frontend seam: tracked seat renders avatar + flair; untracked opponent stays initials-only; broken flair asset hides instead of showing a broken-image glyph

**API evidence** — provider sources (captured live) and what our route returns:

```jsonc
// api.chess.com/pub/player/hikaru → { "avatar": "https://images.chesscomfiles.com/…", … }
// lichess.org/api/user/DrNykterstein → { "flair": "people.santa-claus-light-skin-tone", … }

// GET /api/accounts — new nullable fields on every row
[
  { "id": "…", "platform": "chess_com", "username": "yurimutti",
    "avatarUrl": "https://images.chesscomfiles.com/uploads/v1/user/….jpg",
    "flair": null,
    "lastSyncedAt": "2026-08-23T16:00:00Z", "syncState": "none" },
  { "id": "…", "platform": "lichess", "username": "drnykterstein",
    "avatarUrl": null,
    "flair": "people.santa-claus-light-skin-tone",
    "lastSyncedAt": "2026-08-23T16:00:00Z", "syncState": "none" }
]
```

OpenAPI spec updated with both fields (required + nullable).

**UI evidence** — screenshots attached below:

<img width="266" height="149" alt="image" src="https://github.com/user-attachments/assets/1ce5ba87-1c5c-4477-98fb-0f54ce562c47" />

## Checklist

- [x] `pnpm test`, `pnpm lint`, `pnpm typecheck` pass
- [x] Behavior changes have tests; API changes are in `apps/server/src/openapi.ts` *(template says `apps/api` — renamed since)*
- [x] No unrelated changes