### PR TITLE
fix(platforms): fail soft on profile fetch errors

### DIFF
--- a/libs/infra/platforms/__tests__/profile.test.ts
+++ b/libs/infra/platforms/__tests__/profile.test.ts
@@ -24,6 +24,16 @@ function respondWith(body: unknown, ok = true): typeof globalThis.fetch {
     }) as Response) as typeof globalThis.fetch;
 }
 
+function rejectFetch(error: Error): typeof globalThis.fetch {
+  return (async () => {
+    throw error;
+  }) as typeof globalThis.fetch;
+}
+
+function respondWithInvalidJson(): typeof globalThis.fetch {
+  return (async () => new Response("{")) as typeof globalThis.fetch;
+}
+
 const CHESS_COM_REAL = {
   avatar:
     "https://images.chesscomfiles.com/uploads/v1/user/461825478.97ae265f.200x200o.5fa38b32b080.jpg",
@@ -109,6 +119,14 @@ describe("fetchChessComProfile", () => {
     expect(profile).toEqual({ avatarUrl: null, flair: null, countryCode: null });
   });
 
+  it("comes back empty when the profile request is rejected", async () => {
+    const profile = await fetchChessComProfile("someone", {
+      fetch: rejectFetch(new Error("network error")),
+    });
+
+    expect(profile).toEqual({ avatarUrl: null, flair: null, countryCode: null });
+  });
+
   it("does not call out at all for a username that cannot exist", async () => {
     let called = false;
     const profile = await fetchChessComProfile("!!bad!!", {
@@ -157,6 +175,14 @@ describe("fetchLichessProfile", () => {
     });
 
     expect(profile.flair).toBeNull();
+  });
+
+  it("comes back empty when the profile response is not valid JSON", async () => {
+    const profile = await fetchLichessProfile("someone", {
+      fetch: respondWithInvalidJson(),
+    });
+
+    expect(profile).toEqual({ avatarUrl: null, flair: null, countryCode: null });
   });
 
   it("ignores a flag that is not a country code", async () => {

--- a/libs/infra/platforms/providers/profile.ts
+++ b/libs/infra/platforms/providers/profile.ts
@@ -60,11 +60,15 @@ const lichessProfileSchema = z.object({
 });
 
 async function fetchJson(url: string, doFetch: FetchFn): Promise<unknown | null> {
-  const res = await doFetch(url, { headers: HEADERS });
-  // A profile is decoration around a name. A missing or broken one leaves
-  // the initials in place; it must never fail a game from loading.
-  if (!res.ok) return null;
-  return res.json();
+  try {
+    const res = await doFetch(url, { headers: HEADERS });
+    // A profile is decoration around a name. A missing or broken one leaves
+    // the initials in place; it must never fail a game from loading.
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
 }
 
 export async function fetchChessComProfile(


### PR DESCRIPTION
## What

Closes #14.

Provider profile reads now fail soft when the request rejects, is aborted, or returns invalid JSON. Regression coverage exercises a rejected Chess.com request and an invalid Lichess JSON response.

## Why

Profile metadata is optional decoration around a connected account. A transient provider/network failure should leave the initials fallback in place instead of preventing account connection.

## How

The shared `fetchJson` helper catches errors from both `fetch` and `response.json()` and returns `null`. The existing provider adapters translate that result into an empty profile. Game-sync fetch behavior is unchanged.

## Verification

Red/green evidence:

- Before the implementation, the two new tests failed by propagating `Error: network error` and `SyntaxError`.
- `corepack pnpm exec vitest run --project platforms`: 8 files passed, 1 existing live-test file skipped; 65 tests passed, 2 existing tests skipped.
- Exact profile suite: 15/15 passed.
- `corepack pnpm check`: passed (typecheck, lint, knip; lint reports 13 existing warnings and 0 errors).
- Exact `oxfmt --check` on both changed files and `git diff --check`: passed.

Full-suite boundary:

- `corepack pnpm test` reaches an unchanged Windows-only migration-path failure before completing: `libs/test-utils/db.ts` uses `new URL(...).pathname`, which becomes `/C:/...`; Drizzle then cannot find the existing `libs/infra/db/migrations/meta/_journal.json`. The isolated worker suite reproduces the same baseline failure (6 tests skipped before execution). No database or worker files are changed by this PR.

## Evidence

- Before: rejected fetches and malformed JSON escape the optional profile path.
- After: both cases resolve to `{ avatarUrl: null, flair: null, countryCode: null }`.

## Checklist

- [x] Tests added or updated
- [x] Relevant evidence included
- [x] Migrations verified, if applicable (N/A — no database change)
- [x] Documentation updated, if applicable (N/A — no contract change)
