### PR TITLE
fix(chess): fail soft on profile fetch errors

### DIFF
--- a/libs/infra/platforms/__tests__/profile.test.ts
+++ b/libs/infra/platforms/__tests__/profile.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   countryCodeFromUrl,
+  EMPTY_PROFILE,
   fetchChessComProfile,
   fetchLichessProfile,
 } from "../providers/profile.ts";
@@ -166,5 +167,39 @@ describe("fetchLichessProfile", () => {
     });
 
     expect(profile.countryCode).toBeNull();
+  });
+
+  it("fails soft when fetch rejects (network error)", async () => {
+    const profile = await fetchChessComProfile("someone", {
+      fetch: async () => {
+        throw new Error("network error");
+      },
+    });
+    expect(profile).toEqual(EMPTY_PROFILE);
+  });
+
+  it("fails soft when response body is invalid JSON", async () => {
+    const profile = await fetchChessComProfile("someone", {
+      fetch: async () =>
+        Object.assign(
+          {
+            ok: true,
+            json: async () => {
+              throw new Error("bad json");
+            },
+          },
+          {} as Response,
+        ),
+    });
+    expect(profile).toEqual(EMPTY_PROFILE);
+  });
+
+  it("fails soft when request is aborted", async () => {
+    const profile = await fetchLichessProfile("someone", {
+      fetch: async () => {
+        throw new DOMException("Aborted", "AbortError");
+      },
+    });
+    expect(profile).toEqual(EMPTY_PROFILE);
   });
 });

--- a/libs/infra/platforms/providers/profile.ts
+++ b/libs/infra/platforms/providers/profile.ts
@@ -26,7 +26,7 @@ export interface PlayerProfile {
   countryCode: string | null;
 }
 
-const EMPTY_PROFILE: PlayerProfile = {
+export const EMPTY_PROFILE: PlayerProfile = {
   avatarUrl: null,
   flair: null,
   countryCode: null,
@@ -60,11 +60,15 @@ const lichessProfileSchema = z.object({
 });
 
 async function fetchJson(url: string, doFetch: FetchFn): Promise<unknown | null> {
-  const res = await doFetch(url, { headers: HEADERS });
-  // A profile is decoration around a name. A missing or broken one leaves
-  // the initials in place; it must never fail a game from loading.
-  if (!res.ok) return null;
-  return res.json();
+  try {
+    const res = await doFetch(url, { headers: HEADERS });
+    // A profile is decoration around a name. A missing or broken one leaves
+    // the initials in place; it must never fail a game from loading.
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
 }
 
 export async function fetchChessComProfile(


### PR DESCRIPTION
Wrap `fetchJson` in try/catch so network errors, invalid JSON, and abort exceptions all return `EMPTY_PROFILE` instead of propagating.

- `libs/infra/platforms/providers/profile.ts`: `fetchJson` now catches all exceptions
- `export const EMPTY_PROFILE` added to source  
- `libs/infra/platforms/__tests__/profile.test.ts`: three new tests for failure modes

Fixes velachess/velachess#14