### PR TITLE
feat(auth): Google sign-in, rate limiting, and account settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,18 @@ VELACHESS_AUTH_SECRET=change-me-to-a-random-32-character-secret
 VELACHESS_BASE_URL=http://localhost:5173
 # VELACHESS_TRUSTED_ORIGINS=http://127.0.0.1:5173
 
+# Google sign-in. Both or neither — half-configured refuses to boot.
+# Authorized redirect URI: <VELACHESS_BASE_URL>/auth/callback/google
+# (no /api prefix — Better Auth builds it from its own baseURL, so the
+#  reverse proxy must forward /auth/* to the API as well as /api/*)
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# The reverse proxies in front of the API, as addresses or CIDR ranges.
+# Required when there is one: without it Better Auth cannot resolve a
+# client IP, and its sign-in limit collapses into a single shared bucket.
+# VELACHESS_TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8
+
 # First user, created once into an empty database. Remove after first login.
 VELACHESS_BOOTSTRAP_USER_EMAIL=user@velachess.local
 VELACHESS_BOOTSTRAP_USER_PASSWORD=dev-password

--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,7 @@ VELACHESS_BASE_URL=http://localhost:5173
 # VELACHESS_TRUSTED_ORIGINS=http://127.0.0.1:5173
 
 # Google sign-in. Both or neither — half-configured refuses to boot.
-# Authorized redirect URI: <VELACHESS_BASE_URL>/auth/callback/google
-# (no /api prefix — Better Auth builds it from its own baseURL, so the
-#  reverse proxy must forward /auth/* to the API as well as /api/*)
+# Authorized redirect URI: <VELACHESS_BASE_URL>/api/auth/callback/google
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 

--- a/apps/server/__tests__/auth.test.ts
+++ b/apps/server/__tests__/auth.test.ts
@@ -9,7 +9,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { bootstrapUser } from "@velachess/application/auth/bootstrap-user/bootstrap-user";
-import { createAuth } from "@velachess/auth";
+import { createAuth, GOOGLE_CALLBACK_PATH } from "@velachess/auth";
 import { eq } from "drizzle-orm";
 
 import { schema } from "@velachess/db";
@@ -70,6 +70,10 @@ describe("bootstrap", () => {
 
     const rows = await harness.db.select().from(schema.users);
     expect(rows).toHaveLength(1);
+    // Better Auth's own sign-up writes emailVerified: false; bootstrapUser
+    // corrects it, or this account can never link a Google sign-in on the
+    // same email (Better Auth refuses with account_not_linked, always).
+    expect(rows[0]!.emailVerified).toBe(true);
   });
 
   it("does nothing when the env is not configured", async () => {
@@ -247,14 +251,11 @@ describe("Google sign-in", () => {
     const authorize = new URL(url);
     expect(authorize.origin).toBe("https://accounts.google.com");
     expect(authorize.searchParams.get("client_id")).toBe("client-id");
-    // Pinned deliberately. Better Auth derives this from its own baseURL
-    // and basePath, so it carries NO /api prefix — while the browser
-    // reaches every other auth call under /api. Whatever serves the app
-    // must therefore route /auth/* to this API as well, in production and
-    // in the dev proxy (apps/web/vite.config.ts), or the return leg of
-    // every Google sign-in lands on the SPA and 404s.
+    // Pinned deliberately: an explicit redirectURI (auth.ts) keeps the
+    // OAuth return leg on the same /api/* proxy contract every other auth
+    // call already uses — no second proxy rule to remember.
     expect(authorize.searchParams.get("redirect_uri")).toBe(
-      "https://chess.example.com/auth/callback/google",
+      `https://chess.example.com${GOOGLE_CALLBACK_PATH}`,
     );
     // PKCE, not an implicit flow.
     expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");

--- a/apps/server/__tests__/auth.test.ts
+++ b/apps/server/__tests__/auth.test.ts
@@ -221,6 +221,55 @@ describe("the closed surfaces", () => {
   });
 });
 
+describe("Google sign-in", () => {
+  it("sends the user to Google, and asks to be returned to /auth/callback", async () => {
+    const googleAuth = createAuth({
+      db: harness.db,
+      baseUrl: "https://chess.example.com",
+      secret: "test-secret-at-least-32-characters-long",
+      secureCookies: true,
+      google: { clientId: "client-id", clientSecret: "client-secret" },
+    });
+
+    const response = await googleAuth.handler(
+      new Request("https://chess.example.com/auth/sign-in/social", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "https://chess.example.com",
+        },
+        body: JSON.stringify({ provider: "google", callbackURL: "/" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    const { url } = (await response.json()) as { url: string };
+    const authorize = new URL(url);
+    expect(authorize.origin).toBe("https://accounts.google.com");
+    expect(authorize.searchParams.get("client_id")).toBe("client-id");
+    // Pinned deliberately. Better Auth derives this from its own baseURL
+    // and basePath, so it carries NO /api prefix — while the browser
+    // reaches every other auth call under /api. Whatever serves the app
+    // must therefore route /auth/* to this API as well, in production and
+    // in the dev proxy (apps/web/vite.config.ts), or the return leg of
+    // every Google sign-in lands on the SPA and 404s.
+    expect(authorize.searchParams.get("redirect_uri")).toBe(
+      "https://chess.example.com/auth/callback/google",
+    );
+    // PKCE, not an implicit flow.
+    expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("is not offered when no credentials are configured", async () => {
+    const response = await harness.app.request("/auth/sign-in/social", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider: "google", callbackURL: "/" }),
+    });
+    expect(response.ok).toBe(false);
+  });
+});
+
 describe("secure cookies behind TLS", () => {
   it("an https deployment sets Secure on the session cookie", async () => {
     // The same database, configured the way an https production is —

--- a/apps/server/__tests__/harness.ts
+++ b/apps/server/__tests__/harness.ts
@@ -68,6 +68,10 @@ export async function createApiHarness(
     db: harness.db,
     auth,
     trustedOrigins: [ORIGIN],
+    // Google is not configured in the harness — the suite proves the flag is
+    // reported honestly, and auth.test.ts builds its own configured instance
+    // where the provider matters.
+    signInMethods: { password: true, google: false },
     analysisQueue: harness.analysisQueue,
     // A short interval: the suite should not wait out a production poll.
     watchers: createWatchers({

--- a/apps/server/__tests__/harness.ts
+++ b/apps/server/__tests__/harness.ts
@@ -40,6 +40,10 @@ export interface ApiHarness extends LoopHarness {
   ) => Promise<{ userId: string; cookie: string; app: AuthedApp }>;
 }
 
+/** The origin the harness app is served on — its own baseUrl, and so the
+ * one origin its CSRF check trusts. */
+export const ORIGIN = "http://localhost";
+
 export async function createApiHarness(
   /** The archive GET /games reads through to. Defaults to the looper one. */
   sync: ApiDeps["sync"] = { fetch: chessComFixtureFetch() },
@@ -51,7 +55,7 @@ export async function createApiHarness(
   // cookies off: the test server has no TLS to be secure on.
   const authConfig = {
     db: harness.db,
-    baseUrl: "http://localhost",
+    baseUrl: ORIGIN,
     secret: "test-secret-at-least-32-characters-long",
     secureCookies: false,
   };
@@ -63,6 +67,7 @@ export async function createApiHarness(
   const deps: ApiDeps = {
     db: harness.db,
     auth,
+    trustedOrigins: [ORIGIN],
     analysisQueue: harness.analysisQueue,
     // A short interval: the suite should not wait out a production poll.
     watchers: createWatchers({
@@ -84,6 +89,22 @@ export async function createApiHarness(
   };
 
   const app = createApp(deps);
+
+  // A browser attaches `Origin` to every unsafe request; `app.request`
+  // attaches nothing. The CSRF middleware reads a missing Content-Type as
+  // `text/plain` — i.e. as something a form element could have sent — so
+  // without this every bodyless POST in the suite would meet a 403 that no
+  // real client would ever see. Patched once, here, so the suite exercises
+  // the real middleware chain rather than a chain with a hole in it. A test
+  // that wants to look cross-site passes its own `origin`, which wins.
+  type AppRequest = typeof app.request;
+  const honoRequest: AppRequest = app.request.bind(app);
+  app.request = ((...args: Parameters<AppRequest>) => {
+    const [input, init, ...rest] = args;
+    const headers = new Headers(init?.headers);
+    if (!headers.has("origin")) headers.set("origin", ORIGIN);
+    return honoRequest(input, { ...init, headers }, ...rest);
+  }) as AppRequest;
 
   const signIn = async (email: string, password: string): Promise<string> => {
     const response = await app.request("/auth/sign-in/email", {

--- a/apps/server/__tests__/openapi.test.ts
+++ b/apps/server/__tests__/openapi.test.ts
@@ -65,11 +65,23 @@ it("GET /openapi.json serves the document", async () => {
 it("system routes are registered before the identity middleware", () => {
   // Liveness and documentation must answer even when the db is down —
   // their registration order IS the guarantee (middleware applies only
-  // to routes registered after it).
-  const order = harness.app.routes.map((r) => `${r.method} ${r.path}`);
-  const middleware = order.indexOf("ALL /*");
-  expect(middleware).toBeGreaterThan(order.indexOf("GET /health"));
-  expect(middleware).toBeGreaterThan(order.indexOf("GET /openapi.json"));
+  // to routes registered after it). The gate is found by handler name
+  // rather than by "the first ALL /*", because the edge middleware
+  // (headers, body limit, CSRF) is deliberately registered above these
+  // routes and would otherwise be mistaken for it.
+  const order = harness.app.routes.map((r) => `${r.method} ${r.path} ${r.handler.name}`);
+  const at = (needle: string) => order.findIndex((entry) => entry.includes(needle));
+
+  const gate = at("ALL /* sessionGate");
+  expect(gate).toBeGreaterThan(-1);
+  expect(gate).toBeGreaterThan(at("GET /health"));
+  expect(gate).toBeGreaterThan(at("GET /openapi.json"));
+  // Signing in happens without a session, definitionally.
+  expect(gate).toBeGreaterThan(at("ALL /auth/*"));
+
+  // And the limiter sits below the gate, because every policy is keyed by
+  // the userId the gate resolves — above it there would be nothing to key.
+  expect(at("rateLimited")).toBeGreaterThan(gate);
 });
 
 it("error responses honor the documented { error } contract", async () => {

--- a/apps/server/__tests__/openapi.test.ts
+++ b/apps/server/__tests__/openapi.test.ts
@@ -82,6 +82,16 @@ it("system routes are registered before the identity middleware", () => {
   // And the limiter sits below the gate, because every policy is keyed by
   // the userId the gate resolves — above it there would be nothing to key.
   expect(at("rateLimited")).toBeGreaterThan(gate);
+
+  // Unlike the checks above, this catches a route the list doesn't
+  // already know about — a new endpoint added above the gate, answering
+  // unauthenticated by accident.
+  const above = new Set(
+    harness.app.routes.slice(0, gate).map((r) => `${r.method} ${r.path}`),
+  );
+  expect(above).toEqual(
+    new Set(["ALL /*", "GET /health", "GET /config", "GET /openapi.json", "ALL /auth/*"]),
+  );
 });
 
 it("error responses honor the documented { error } contract", async () => {

--- a/apps/server/__tests__/security.test.ts
+++ b/apps/server/__tests__/security.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment node
+/**
+ * The edge every request crosses before a route sees it: secure headers,
+ * a body ceiling, an origin check, and the per-user budgets.
+ *
+ * All of it over the real harness app — the same middleware chain
+ * production assembles, in the same order, because the order is most of
+ * the security property.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+
+import { createApp } from "../src/server.ts";
+import { POLICIES } from "../src/middleware/rate-limit.ts";
+import { createApiHarness, ORIGIN, type ApiHarness, type AuthedApp } from "./harness.ts";
+
+let harness: ApiHarness;
+let user: { userId: string; cookie: string; app: AuthedApp };
+
+beforeAll(async () => {
+  harness = await createApiHarness();
+  user = await harness.signUp("edge@velachess.local");
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+/** A route that is cheap to call and cannot succeed — the limiter runs
+ * before the handler, so a 404 past it is all these tests need. */
+const sync = () => `/accounts/${randomUUID()}/sync`;
+
+describe("rate limiting", () => {
+  it("refuses past the policy's budget, and says when to come back", async () => {
+    const limited = await harness.signUp("throttled@velachess.local");
+
+    for (let i = 0; i < POLICIES.import.max; i++) {
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      const response = await limited.app.request(sync(), { method: "POST" });
+      expect(response.status, `request ${i + 1}`).not.toBe(429);
+    }
+
+    const refused = await limited.app.request(sync(), { method: "POST" });
+    expect(refused.status).toBe(429);
+    expect(await refused.json()).toEqual({ error: "too many requests" });
+
+    // The standard header, in whole seconds, and never 0 — a client told
+    // to wait zero seconds retries immediately.
+    const retryAfter = Number(refused.headers.get("retry-after"));
+    expect(retryAfter).toBeGreaterThan(0);
+    expect(retryAfter).toBeLessThanOrEqual(POLICIES.import.windowSeconds);
+  });
+
+  it("is one budget per user, not one for the API", async () => {
+    // The previous user is over the import limit. A different session is
+    // unaffected: the key is the userId the session proved, so nobody can
+    // throttle anybody else.
+    const other = await harness.signUp("unthrottled@velachess.local");
+    const response = await other.app.request(sync(), { method: "POST" });
+    expect(response.status).not.toBe(429);
+  });
+
+  it("holds across processes, because it lives in Postgres", async () => {
+    // A second app over the same database stands in for a second API
+    // instance behind the load balancer. An in-memory counter would give
+    // this user a fresh budget here; a shared one does not.
+    const second = createApp(harness.deps);
+    const spender = await harness.signUp("shared@velachess.local");
+
+    for (let i = 0; i < POLICIES.import.max; i++) {
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      await spender.app.request(sync(), { method: "POST" });
+    }
+
+    const response = await second.request(sync(), {
+      method: "POST",
+      headers: { cookie: spender.cookie, origin: ORIGIN },
+    });
+    expect(response.status).toBe(429);
+  });
+
+  it("leaves the liveness probe alone", async () => {
+    // /health sits above the gate and outside every policy on purpose: a
+    // probe that can be throttled is a probe that lies during an incident.
+    for (let i = 0; i < POLICIES.import.max + 5; i++) {
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      const response = await harness.app.request("/health");
+      expect(response.status).toBe(200);
+    }
+  });
+});
+
+describe("the request edge", () => {
+  it("refuses a body past the ceiling before parsing it", async () => {
+    const oversized = "x".repeat(300 * 1024);
+    const response = await user.app.request("/repertoires", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: oversized, color: "white" }),
+    });
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: "payload too large" });
+  });
+
+  it("accepts a normal body on the same route", async () => {
+    const response = await user.app.request("/repertoires", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "White e4", color: "white" }),
+    });
+    expect(response.ok).toBe(true);
+  });
+
+  it("rejects a cross-site form post carrying the session cookie", async () => {
+    // The shape of a real CSRF attempt: a form on another origin, posting
+    // with the browser's cookies attached. It is refused before the
+    // session is even looked up.
+    const response = await harness.app.request("/repertoires", {
+      method: "POST",
+      headers: {
+        origin: "https://evil.example",
+        cookie: user.cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: "name=Stolen&color=white",
+    });
+    expect(response.status).toBe(403);
+    // Never `{ error: "" }` — hono's csrf throws without a message.
+    expect(await response.json()).toEqual({ error: "request rejected" });
+  });
+
+  it("rejects a cross-site request that declares no content type", async () => {
+    // A missing Content-Type is form-postable too, so it is checked the
+    // same way rather than waved through.
+    const response = await harness.app.request("/repertoires", {
+      method: "POST",
+      headers: { origin: "https://evil.example", cookie: user.cookie },
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("lets the app's own origin through", async () => {
+    const response = await harness.app.request("/overview", {
+      headers: { origin: ORIGIN, cookie: user.cookie },
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it("sends the baseline security headers on every answer", async () => {
+    for (const path of ["/health", "/overview"]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      const response = await harness.app.request(path, {
+        headers: { cookie: user.cookie },
+      });
+      expect(response.headers.get("x-content-type-options"), path).toBe("nosniff");
+      expect(response.headers.get("referrer-policy"), path).toBeTruthy();
+      // No API answer should ever be framed.
+      expect(response.headers.get("x-frame-options"), path).toBeTruthy();
+    }
+  });
+});
+
+describe("what sits above the session gate", () => {
+  it("is exactly health, the spec, and Better Auth", async () => {
+    // Anything else answering without a cookie would be a route mounted
+    // above the gate by accident — the failure this test exists to catch.
+    for (const path of ["/health", "/openapi.json"]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      const response = await harness.app.request(path);
+      expect(response.status, path).toBe(200);
+    }
+
+    // Auth answers without a session (that is what signing in is), but it
+    // is Better Auth answering, not one of our routes.
+    const session = await harness.app.request("/auth/get-session");
+    expect(session.status).toBe(200);
+    expect(await session.json()).toBeNull();
+
+    for (const path of [
+      "/overview",
+      "/games",
+      "/repertoires",
+      "/deviations",
+      "/drill/queue",
+      "/insights",
+      "/accounts",
+    ]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      const response = await harness.app.request(path);
+      expect(response.status, path).toBe(401);
+    }
+  });
+});

--- a/apps/server/__tests__/security.test.ts
+++ b/apps/server/__tests__/security.test.ts
@@ -42,13 +42,22 @@ describe("rate limiting", () => {
 
     const refused = await limited.app.request(sync(), { method: "POST" });
     expect(refused.status).toBe(429);
-    expect(await refused.json()).toEqual({ error: "too many requests" });
 
-    // The standard header, in whole seconds, and never 0 — a client told
-    // to wait zero seconds retries immediately.
-    const retryAfter = Number(refused.headers.get("retry-after"));
-    expect(retryAfter).toBeGreaterThan(0);
-    expect(retryAfter).toBeLessThanOrEqual(POLICIES.import.windowSeconds);
+    // The wait lives in the body as well as the header, because the SPA's
+    // client can only read the body of a rejection — same contract as the
+    // sync cooldown. Never 0: a client told to wait zero seconds retries
+    // immediately, which is the behaviour the refusal exists to prevent.
+    const body = (await refused.json()) as {
+      error: string;
+      retryAfterSeconds: number;
+    };
+    expect(body.error).toBe("too many requests");
+    expect(body.retryAfterSeconds).toBeGreaterThan(0);
+    expect(body.retryAfterSeconds).toBeLessThanOrEqual(POLICIES.import.windowSeconds);
+
+    // And the header says the same number — two answers that disagree
+    // would teach clients to trust neither.
+    expect(Number(refused.headers.get("retry-after"))).toBe(body.retryAfterSeconds);
   });
 
   it("is one budget per user, not one for the API", async () => {

--- a/apps/server/__tests__/security.test.ts
+++ b/apps/server/__tests__/security.test.ts
@@ -160,15 +160,59 @@ describe("the request edge", () => {
   });
 });
 
+describe("CORS", () => {
+  it("answers a preflight from a trusted origin, with credentials", async () => {
+    const response = await harness.app.request("/overview", {
+      method: "OPTIONS",
+      headers: {
+        origin: ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+    expect(response.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    // Without this the browser drops the session cookie on a cross-origin
+    // request, and the deployment fails in a way that looks like "logged out".
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(response.headers.get("access-control-allow-headers")).toContain(
+      "Content-Type",
+    );
+  });
+
+  it("declines to name an untrusted origin", async () => {
+    const response = await harness.app.request("/overview", {
+      method: "OPTIONS",
+      headers: { origin: "https://evil.example", "access-control-request-method": "GET" },
+    });
+    // Hono answers the preflight either way; what matters is that it never
+    // echoes an origin it was not told to trust, so the browser refuses.
+    expect(response.headers.get("access-control-allow-origin")).not.toBe(
+      "https://evil.example",
+    );
+  });
+
+  it("never widens to a wildcard", async () => {
+    const response = await harness.app.request("/health", {
+      headers: { origin: ORIGIN },
+    });
+    expect(response.headers.get("access-control-allow-origin")).not.toBe("*");
+  });
+});
+
 describe("what sits above the session gate", () => {
   it("is exactly health, the spec, and Better Auth", async () => {
     // Anything else answering without a cookie would be a route mounted
     // above the gate by accident — the failure this test exists to catch.
-    for (const path of ["/health", "/openapi.json"]) {
+    for (const path of ["/health", "/config", "/openapi.json"]) {
       // oxlint-disable-next-line eslint/no-await-in-loop
       const response = await harness.app.request(path);
       expect(response.status, path).toBe(200);
     }
+
+    // /config is public on purpose, so what it carries matters: capability
+    // flags, and nothing that could identify a person or a credential.
+    const config = await (await harness.app.request("/config")).json();
+    expect(config).toEqual({ signInMethods: { password: true, google: false } });
 
     // Auth answers without a session (that is what signing in is), but it
     // is Better Auth answering, not one of our routes.

--- a/apps/server/__tests__/security.test.ts
+++ b/apps/server/__tests__/security.test.ts
@@ -27,20 +27,22 @@ afterAll(async () => {
 });
 
 /** A route that is cheap to call and cannot succeed — the limiter runs
- * before the handler, so a 404 past it is all these tests need. */
-const sync = () => `/accounts/${randomUUID()}/sync`;
+ * before the handler, so a 404 past it is all these tests need. Callers
+ * that care about the budget reuse one id; callers that don't, don't. */
+const sync = (accountId: string = randomUUID()) => `/accounts/${accountId}/sync`;
 
 describe("rate limiting", () => {
   it("refuses past the policy's budget, and says when to come back", async () => {
     const limited = await harness.signUp("throttled@velachess.local");
+    const accountId = randomUUID();
 
     for (let i = 0; i < POLICIES.import.max; i++) {
       // oxlint-disable-next-line eslint/no-await-in-loop
-      const response = await limited.app.request(sync(), { method: "POST" });
+      const response = await limited.app.request(sync(accountId), { method: "POST" });
       expect(response.status, `request ${i + 1}`).not.toBe(429);
     }
 
-    const refused = await limited.app.request(sync(), { method: "POST" });
+    const refused = await limited.app.request(sync(accountId), { method: "POST" });
     expect(refused.status).toBe(429);
 
     // The wait lives in the body as well as the header, because the SPA's
@@ -75,17 +77,36 @@ describe("rate limiting", () => {
     // this user a fresh budget here; a shared one does not.
     const second = createApp(harness.deps);
     const spender = await harness.signUp("shared@velachess.local");
+    const accountId = randomUUID();
 
     for (let i = 0; i < POLICIES.import.max; i++) {
       // oxlint-disable-next-line eslint/no-await-in-loop
-      await spender.app.request(sync(), { method: "POST" });
+      await spender.app.request(sync(accountId), { method: "POST" });
     }
 
-    const response = await second.request(sync(), {
+    const response = await second.request(sync(accountId), {
       method: "POST",
       headers: { cookie: spender.cookie, origin: ORIGIN },
     });
     expect(response.status).toBe(429);
+  });
+
+  it("budgets separately per account, so tracking several does not throttle the first", async () => {
+    // Keyed by (userId, accountId) — see server.ts's mount of
+    // POLICIES.import. A user syncing six accounts must get six full
+    // budgets, not one shared across all of them.
+    const owner = await harness.signUp("multi-account@velachess.local");
+    const first = randomUUID();
+
+    for (let i = 0; i < POLICIES.import.max; i++) {
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      await owner.app.request(sync(first), { method: "POST" });
+    }
+    const firstExhausted = await owner.app.request(sync(first), { method: "POST" });
+    expect(firstExhausted.status).toBe(429);
+
+    const second = await owner.app.request(sync(randomUUID()), { method: "POST" });
+    expect(second.status).not.toBe(429);
   });
 
   it("leaves the liveness probe alone", async () => {

--- a/apps/server/src/deps.ts
+++ b/apps/server/src/deps.ts
@@ -13,6 +13,17 @@ import type { Scheduler } from "@velachess/scheduler";
 
 import type { Watchers } from "@velachess/application/analysis/watch-analysis/watchers";
 
+/**
+ * What the sign-in screen may render. Capability flags, nothing more: the
+ * screen has to know which methods exist *before* it has a session, and a
+ * self-host with no Google credentials must not show a button whose only
+ * possible outcome is an error at the redirect.
+ */
+interface SignInMethods {
+  password: boolean;
+  google: boolean;
+}
+
 export interface ApiDeps {
   db: Database;
   /** Answers exactly one question: who is making this request. */
@@ -21,6 +32,8 @@ export interface ApiDeps {
    * auth config resolves from VELACHESS_BASE_URL, so a request the session
    * would accept and a request CSRF would accept cannot disagree. */
   trustedOrigins: string[];
+  /** Served publicly at GET /config — see SignInMethods. */
+  signInMethods: SignInMethods;
   analysisQueue: AnalysisQueue;
   syncQueue: SyncQueue;
   scheduler: Scheduler;

--- a/apps/server/src/deps.ts
+++ b/apps/server/src/deps.ts
@@ -17,6 +17,10 @@ export interface ApiDeps {
   db: Database;
   /** Answers exactly one question: who is making this request. */
   auth: Auth;
+  /** Origins the CSRF check accepts on unsafe methods. The same list the
+   * auth config resolves from VELACHESS_BASE_URL, so a request the session
+   * would accept and a request CSRF would accept cannot disagree. */
+  trustedOrigins: string[];
   analysisQueue: AnalysisQueue;
   syncQueue: SyncQueue;
   scheduler: Scheduler;

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -69,6 +69,11 @@ const authConfig = {
   // Never weakened for production; localhost simply has no TLS.
   secureCookies: authEnv.secureCookies,
   trustedOrigins: authEnv.trustedOrigins,
+  // Both optional and both spread rather than passed as `undefined`: an
+  // absent Google config means the provider is not offered at all, and an
+  // absent proxy list means the socket address is already the client's.
+  ...(authEnv.google ? { google: authEnv.google } : {}),
+  ...(authEnv.trustedProxies ? { trustedProxies: authEnv.trustedProxies } : {}),
 };
 
 // The instance the HTTP server mounts: sign-up closed. A self-hosted
@@ -96,6 +101,7 @@ apiLogger.info({ bootstrap }, "first-user bootstrap");
 const app = createApp({
   db,
   auth,
+  trustedOrigins: authEnv.trustedOrigins,
   analysisQueue,
   watchers: createWatchers({ db, analysisQueue }),
   syncQueue: makeSyncQueue(boss, db),

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -102,6 +102,10 @@ const app = createApp({
   db,
   auth,
   trustedOrigins: authEnv.trustedOrigins,
+  // Password sign-in is always available; Google appears only where it is
+  // configured. Derived from the same resolved env the auth instance is built
+  // from, so the screen and the server cannot disagree about what exists.
+  signInMethods: { password: true, google: Boolean(authEnv.google) },
   analysisQueue,
   watchers: createWatchers({ db, analysisQueue }),
   syncQueue: makeSyncQueue(boss, db),

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -1,21 +1,10 @@
 /**
- * Rate limiting for the application's own routes.
- *
- * Deliberately NOT applied to `/auth/*`. Better Auth ships its own limiter
- * with stricter built-in rules for the sensitive endpoints (`/sign-in*`,
- * `/sign-up*`, password reset and friends), and it is configured here with
- * `storage: "database"` so it is distributed too. Putting a second limiter
- * in front of it would duplicate the protection and split the accounting
- * across two tables that disagree.
- *
- * There is also no client-IP resolution here, and that is the point: every
- * policy below is keyed by `userId`, which the session already proved. No
- * `X-Forwarded-For` parsing means no trusted-proxy list to get wrong and no
- * header a client can forge to escape its own limit. The two public routes
- * — `/health` and `/openapi.json` — are cheap and static; crude anonymous
- * abuse belongs to the reverse proxy, not to a database round-trip.
+ * Rate limiting for the application's own routes, keyed by the
+ * authenticated `userId` — not applied to `/auth/*` (Better Auth throttles
+ * that itself) and not by client IP, so there is no proxy header to trust.
  */
 
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 
 import { consumeRateLimit, type RateLimitPolicy } from "@velachess/db";
@@ -23,38 +12,31 @@ import { consumeRateLimit, type RateLimitPolicy } from "@velachess/db";
 import type { ApiEnv } from "../server.ts";
 import type { ApiDeps } from "../deps.ts";
 
-/**
- * One budget per shape of cost, not one budget for "the API".
- *
- * A read of the games list and a request to analyse one differ by four
- * orders of magnitude in what they ask of the machine, so they cannot
- * share a counter. `import` is stricter still because it also spends
- * somebody else's quota — chess.com's and Lichess's.
- */
+/** One budget per shape of cost: a list read and an analysis request differ
+ * by orders of magnitude, and import also spends someone else's quota. */
 export const POLICIES = {
   authenticated: { name: "api", max: 300, windowSeconds: 60 },
   import: { name: "import", max: 5, windowSeconds: 60 },
   expensive: { name: "analysis", max: 20, windowSeconds: 60 },
 } as const satisfies Record<string, RateLimitPolicy>;
 
-export function rateLimit(deps: ApiDeps, policy: RateLimitPolicy) {
-  // Named for the same reason as the session gate: it must be provably
-  // registered after it, since every policy is keyed by the userId the
-  // session resolves.
+export function rateLimit(
+  deps: ApiDeps,
+  policy: RateLimitPolicy,
+  // Defaults to the whole user; a route budgeting a per-resource cost
+  // (e.g. one account's sync) passes its own to avoid one resource's
+  // traffic exhausting every other resource's budget.
+  subject: (c: Context<ApiEnv>) => string = (c) => c.get("userId"),
+) {
+  // Named so __tests__/openapi.test.ts can assert it is registered below
+  // the session gate, since every policy is keyed by the userId it resolves.
   return createMiddleware<ApiEnv>(async function rateLimited(c, next) {
-    const verdict = await consumeRateLimit(deps.db, c.get("userId"), policy);
+    const verdict = await consumeRateLimit(deps.db, subject(c), policy);
 
     if (!verdict.allowed) {
-      // Returned, not thrown — the same pattern as the sync cooldown in
-      // routes/accounts.ts, and for the same reason: the wait belongs in
-      // the BODY. The SPA's client (hono's `parseResponse`) surfaces only
-      // status and body of a rejection, never headers, so a wait that
-      // lived in `Retry-After` alone would be invisible to the UI.
-      //
-      // The header is still sent for everything that is not our SPA —
-      // it is the standard, and curl and proxies read it. Better Auth
-      // answers its own throttling with `X-Retry-After` instead; that
-      // asymmetry is the library's, not a slip here.
+      // Returned, not thrown: the SPA's client surfaces only status and
+      // body on a rejection, never headers, so the wait belongs in the
+      // body. `Retry-After` is still sent for non-SPA callers.
       return c.json(
         {
           error: "too many requests",

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -1,0 +1,62 @@
+/**
+ * Rate limiting for the application's own routes.
+ *
+ * Deliberately NOT applied to `/auth/*`. Better Auth ships its own limiter
+ * with stricter built-in rules for the sensitive endpoints (`/sign-in*`,
+ * `/sign-up*`, password reset and friends), and it is configured here with
+ * `storage: "database"` so it is distributed too. Putting a second limiter
+ * in front of it would duplicate the protection and split the accounting
+ * across two tables that disagree.
+ *
+ * There is also no client-IP resolution here, and that is the point: every
+ * policy below is keyed by `userId`, which the session already proved. No
+ * `X-Forwarded-For` parsing means no trusted-proxy list to get wrong and no
+ * header a client can forge to escape its own limit. The two public routes
+ * — `/health` and `/openapi.json` — are cheap and static; crude anonymous
+ * abuse belongs to the reverse proxy, not to a database round-trip.
+ */
+
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
+
+import { consumeRateLimit, type RateLimitPolicy } from "@velachess/db";
+
+import type { ApiEnv } from "../server.ts";
+import type { ApiDeps } from "../deps.ts";
+
+/**
+ * One budget per shape of cost, not one budget for "the API".
+ *
+ * A read of the games list and a request to analyse one differ by four
+ * orders of magnitude in what they ask of the machine, so they cannot
+ * share a counter. `import` is stricter still because it also spends
+ * somebody else's quota — chess.com's and Lichess's.
+ */
+export const POLICIES = {
+  authenticated: { name: "api", max: 300, windowSeconds: 60 },
+  import: { name: "import", max: 5, windowSeconds: 60 },
+  expensive: { name: "analysis", max: 20, windowSeconds: 60 },
+} as const satisfies Record<string, RateLimitPolicy>;
+
+export function rateLimit(deps: ApiDeps, policy: RateLimitPolicy) {
+  // Named for the same reason as the session gate: it must be provably
+  // registered after it, since every policy is keyed by the userId the
+  // session resolves.
+  return createMiddleware<ApiEnv>(async function rateLimited(c, next) {
+    const verdict = await consumeRateLimit(deps.db, c.get("userId"), policy);
+
+    if (!verdict.allowed) {
+      // The standard header, in seconds. Better Auth answers its own
+      // throttling with `X-Retry-After` instead — that asymmetry is the
+      // library's, not a slip here, and "fixing" one of the two would
+      // break whichever client learned to read it.
+      c.header("Retry-After", String(verdict.retryAfterSeconds));
+      // HTTPException so `onError` renders the same `{ error }` shape as
+      // every other rejection — a throttled request is not a special
+      // wire format.
+      throw new HTTPException(429, { message: "too many requests" });
+    }
+
+    await next();
+  });
+}

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -17,7 +17,6 @@
  */
 
 import { createMiddleware } from "hono/factory";
-import { HTTPException } from "hono/http-exception";
 
 import { consumeRateLimit, type RateLimitPolicy } from "@velachess/db";
 
@@ -46,15 +45,24 @@ export function rateLimit(deps: ApiDeps, policy: RateLimitPolicy) {
     const verdict = await consumeRateLimit(deps.db, c.get("userId"), policy);
 
     if (!verdict.allowed) {
-      // The standard header, in seconds. Better Auth answers its own
-      // throttling with `X-Retry-After` instead — that asymmetry is the
-      // library's, not a slip here, and "fixing" one of the two would
-      // break whichever client learned to read it.
-      c.header("Retry-After", String(verdict.retryAfterSeconds));
-      // HTTPException so `onError` renders the same `{ error }` shape as
-      // every other rejection — a throttled request is not a special
-      // wire format.
-      throw new HTTPException(429, { message: "too many requests" });
+      // Returned, not thrown — the same pattern as the sync cooldown in
+      // routes/accounts.ts, and for the same reason: the wait belongs in
+      // the BODY. The SPA's client (hono's `parseResponse`) surfaces only
+      // status and body of a rejection, never headers, so a wait that
+      // lived in `Retry-After` alone would be invisible to the UI.
+      //
+      // The header is still sent for everything that is not our SPA —
+      // it is the standard, and curl and proxies read it. Better Auth
+      // answers its own throttling with `X-Retry-After` instead; that
+      // asymmetry is the library's, not a slip here.
+      return c.json(
+        {
+          error: "too many requests",
+          retryAfterSeconds: verdict.retryAfterSeconds,
+        },
+        429,
+        { "Retry-After": String(verdict.retryAfterSeconds) },
+      );
     }
 
     await next();

--- a/apps/server/src/middleware/session.ts
+++ b/apps/server/src/middleware/session.ts
@@ -11,7 +11,10 @@ import type { Auth } from "@velachess/auth";
 import type { ApiEnv } from "../server.ts";
 
 export function sessionMiddleware(auth: Auth) {
-  return createMiddleware<ApiEnv>(async (c, next) => {
+  // Named, not anonymous: hono records the handler on `app.routes`, and
+  // the identity gate's position in that list is an invariant the suite
+  // asserts (__tests__/openapi.test.ts). A name makes it findable.
+  return createMiddleware<ApiEnv>(async function sessionGate(c, next) {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
     if (!session) throw new HTTPException(401, { message: "unauthorized" });
     c.set("userId", session.user.id);

--- a/apps/server/src/openapi.ts
+++ b/apps/server/src/openapi.ts
@@ -77,6 +77,32 @@ export const openApiSpec = {
         },
       },
     },
+    "/config": {
+      get: {
+        summary: "What this deployment offers, before anyone signs in",
+        description:
+          "Public by necessity: the sign-in screen has to know which methods exist before it can render them, and it has no session yet. Carries capability flags only — never credentials, never anything about a user.",
+        responses: {
+          "200": {
+            description: "Sign-in methods this instance actually offers",
+            ...jsonOf({
+              type: "object",
+              properties: {
+                signInMethods: {
+                  type: "object",
+                  properties: {
+                    password: { type: "boolean" },
+                    google: { type: "boolean" },
+                  },
+                  required: ["password", "google"],
+                },
+              },
+              required: ["signInMethods"],
+            }),
+          },
+        },
+      },
+    },
     "/openapi.json": {
       get: {
         summary: "This document",

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -7,6 +7,7 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { except } from "hono/combine";
+import { cors } from "hono/cors";
 import { csrf } from "hono/csrf";
 import { HTTPException } from "hono/http-exception";
 import { secureHeaders } from "hono/secure-headers";
@@ -51,6 +52,28 @@ export function createApp(deps: ApiDeps) {
     // proxy in front of the SPA, not here. What matters for an API is
     // nosniff and a referrer policy, which are the middleware's defaults.
     .use("*", secureHeaders())
+    // Declared before every route, as hono's docs require ("should be called
+    // before the route"), and mirroring Better Auth's Hono guide: an explicit
+    // origin list rather than a wildcard, `credentials: true` because the
+    // session rides in a cookie, and the very same list Better Auth trusts —
+    // one source of truth, so CORS and the session cannot disagree about who
+    // is allowed to talk to this API.
+    //
+    // Today that list is the app's own origin, and a same-origin request
+    // carries no Origin header worth answering, so this middleware is
+    // effectively inert. It exists for the deployment that puts the SPA on a
+    // separate host, and it fails closed until that host is declared.
+    .use(
+      "*",
+      cors({
+        origin: deps.trustedOrigins,
+        credentials: true,
+        // What the SPA actually sends. Anything else is not a request this
+        // API knows how to serve.
+        allowHeaders: ["Content-Type"],
+        maxAge: 600,
+      }),
+    )
     // Refuse an oversized body before anything spends effort parsing it.
     .use(
       "*",
@@ -73,6 +96,9 @@ export function createApp(deps: ApiDeps) {
     // System routes — liveness and documentation answer even when the
     // database is down; identity never touches them.
     .get("/health", (c) => c.json({ ok: true }))
+    // Public because the sign-in screen consumes it before there is anyone to
+    // authenticate. Capability flags only — see SignInMethods in deps.ts.
+    .get("/config", (c) => c.json({ signInMethods: deps.signInMethods }))
     .get("/openapi.json", (c) => c.json(openApiSpec))
     // Better Auth owns everything under /auth/* — sign-in, sign-out,
     // session, sign-up. Mounted before the session gate because logging

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -6,6 +6,7 @@
 
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import type { ApplyGlobalResponse } from "hono/client";
 import { cors } from "hono/cors";
 import { csrf } from "hono/csrf";
 import { HTTPException } from "hono/http-exception";
@@ -153,5 +154,26 @@ export function createApp(deps: ApiDeps) {
   return app;
 }
 
+/**
+ * Every status a route's own handler chain never declares, because it
+ * comes from onError/notFound or from middleware mounted via `.use()`
+ * rather than a route's own `.get`/`.post` chain (401 the session gate,
+ * 403 csrf, 404 unknown paths, 413 the body ceiling, 429 the rate
+ * limiter, 500 unhandled) — hono's RPC inference can't see any of these
+ * on its own, so a client reading `res.status === 429` would get `never`
+ * for the body without this.
+ */
+type GlobalErrorResponses = {
+  401: { json: { error: string } };
+  403: { json: { error: string } };
+  404: { json: { error: string } };
+  413: { json: { error: string } };
+  429: { json: { error: string; retryAfterSeconds: number } };
+  500: { json: { error: string } };
+};
+
 /** Type-only contract for clients (hono/client). Never import the value. */
-export type AppType = ReturnType<typeof createApp>;
+export type AppType = ApplyGlobalResponse<
+  ReturnType<typeof createApp>,
+  GlobalErrorResponses
+>;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -5,11 +5,16 @@
  */
 
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { except } from "hono/combine";
+import { csrf } from "hono/csrf";
 import { HTTPException } from "hono/http-exception";
+import { secureHeaders } from "hono/secure-headers";
 
 import { logger } from "@velachess/logger";
 
 import type { ApiDeps } from "./deps.ts";
+import { POLICIES, rateLimit } from "./middleware/rate-limit.ts";
 import { sessionMiddleware } from "./middleware/session.ts";
 import { openApiSpec } from "./openapi.ts";
 import { accountsRoutes } from "./routes/accounts.ts";
@@ -28,18 +33,64 @@ export interface ApiEnv {
   };
 }
 
+/**
+ * The largest body any route legitimately sends. The biggest one is a PGN
+ * paste; 256 KiB is a very long game with room to spare, and refusing
+ * beyond it costs nothing while an unbounded POST is cheap denial of
+ * service.
+ */
+const MAX_BODY_BYTES = 256 * 1024;
+
 export function createApp(deps: ApiDeps) {
   const app = new Hono<ApiEnv>()
-    // System routes first — liveness and documentation answer even when
-    // the database is down; identity never touches them.
+    // Headers first, so they cover every response — including the opaque
+    // 500 that `onError` produces at the very bottom.
+    //
+    // No CSP: this app answers JSON. A content policy governs what a
+    // *document* may load, and the document is served by the reverse
+    // proxy in front of the SPA, not here. What matters for an API is
+    // nosniff and a referrer policy, which are the middleware's defaults.
+    .use("*", secureHeaders())
+    // Refuse an oversized body before anything spends effort parsing it.
+    .use(
+      "*",
+      bodyLimit({
+        maxSize: MAX_BODY_BYTES,
+        onError: () => {
+          throw new HTTPException(413, { message: "payload too large" });
+        },
+      }),
+    )
+    // Origin check on unsafe methods. The session rides in a cookie, so a
+    // forged cross-site POST would otherwise arrive authenticated — and it
+    // is rejected here, before it can even cost a session lookup.
+    //
+    // No CORS beside it, deliberately: the SPA fetches `/api` on its own
+    // origin (apps/web/src/shared/api/client.ts), so there is no second
+    // origin to authorise. Adding a permissive list would widen a surface
+    // that does not currently exist.
+    .use("*", csrf({ origin: deps.trustedOrigins }))
+    // System routes — liveness and documentation answer even when the
+    // database is down; identity never touches them.
     .get("/health", (c) => c.json({ ok: true }))
     .get("/openapi.json", (c) => c.json(openApiSpec))
     // Better Auth owns everything under /auth/* — sign-in, sign-out,
     // session, sign-up. Mounted before the session gate because logging
     // in is, definitionally, done without a session. The handler shape is
     // the official Hono integration: forward the raw Request.
+    //
+    // It throttles itself: `rateLimit.storage: "database"` in
+    // libs/infra/auth, with its own stricter rules for the sensitive
+    // endpoints. No limiter of ours in front of it.
     .all("/auth/*", (c) => deps.auth.handler(c.req.raw))
     .use("*", sessionMiddleware(deps.auth))
+    // Everything past the gate has a userId, which is what every policy is
+    // keyed by. /health is exempt: a liveness probe that can be throttled
+    // is a liveness probe that lies during an incident.
+    .use("*", except("/health", rateLimit(deps, POLICIES.authenticated)))
+    // Costlier actions get their own budget on top of the general one.
+    .use("/accounts/:id/sync", rateLimit(deps, POLICIES.import))
+    .use("/games/:id/analyze", rateLimit(deps, POLICIES.expensive))
     .route("/accounts", accountsRoutes(deps))
     .route("/games", gamesRoutes(deps))
     .route("/deviations", deviationsRoutes(deps))
@@ -58,7 +109,10 @@ export function createApp(deps: ApiDeps) {
   app.notFound((c) => c.json({ error: "not found" }, 404));
   app.onError((error, c) => {
     if (error instanceof HTTPException) {
-      return c.json({ error: error.message }, error.status);
+      // hono's own csrf middleware throws a message-less 403 (it carries a
+      // plain-text Response instead), so there is a fallback rather than an
+      // `{ error: "" }` a client cannot act on.
+      return c.json({ error: error.message || "request rejected" }, error.status);
     }
     apiLogger.error(
       { error, method: c.req.method, path: c.req.path },

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -6,7 +6,6 @@
 
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { except } from "hono/combine";
 import { cors } from "hono/cors";
 import { csrf } from "hono/csrf";
 import { HTTPException } from "hono/http-exception";
@@ -63,6 +62,9 @@ export function createApp(deps: ApiDeps) {
     // carries no Origin header worth answering, so this middleware is
     // effectively inert. It exists for the deployment that puts the SPA on a
     // separate host, and it fails closed until that host is declared.
+    //
+    // Also the layer that stops a forged JSON fetch() — see csrf() below
+    // for the request class this one doesn't cover.
     .use(
       "*",
       cors({
@@ -74,7 +76,6 @@ export function createApp(deps: ApiDeps) {
         maxAge: 600,
       }),
     )
-    // Refuse an oversized body before anything spends effort parsing it.
     .use(
       "*",
       bodyLimit({
@@ -84,14 +85,11 @@ export function createApp(deps: ApiDeps) {
         },
       }),
     )
-    // Origin check on unsafe methods. The session rides in a cookie, so a
-    // forged cross-site POST would otherwise arrive authenticated — and it
-    // is rejected here, before it can even cost a session lookup.
-    //
-    // No CORS beside it, deliberately: the SPA fetches `/api` on its own
-    // origin (apps/web/src/shared/api/client.ts), so there is no second
-    // origin to authorise. Adding a permissive list would widen a surface
-    // that does not currently exist.
+    // Origin check for requests CORS never sees: a plain <form> POST needs
+    // no preflight (content-type form-urlencoded/multipart/text-plain, or
+    // absent), so it reaches here un-vetted — and SameSite=Lax lets a
+    // top-level form submission carry the cookie cross-site regardless.
+    // A JSON fetch() never matches this check; that's CORS's job, above.
     .use("*", csrf({ origin: deps.trustedOrigins }))
     // System routes — liveness and documentation answer even when the
     // database is down; identity never touches them.
@@ -103,19 +101,24 @@ export function createApp(deps: ApiDeps) {
     // Better Auth owns everything under /auth/* — sign-in, sign-out,
     // session, sign-up. Mounted before the session gate because logging
     // in is, definitionally, done without a session. The handler shape is
-    // the official Hono integration: forward the raw Request.
-    //
-    // It throttles itself: `rateLimit.storage: "database"` in
-    // libs/infra/auth, with its own stricter rules for the sensitive
-    // endpoints. No limiter of ours in front of it.
+    // the official Hono integration: forward the raw Request. It throttles
+    // itself; no limiter of ours in front of it.
     .all("/auth/*", (c) => deps.auth.handler(c.req.raw))
     .use("*", sessionMiddleware(deps.auth))
-    // Everything past the gate has a userId, which is what every policy is
-    // keyed by. /health is exempt: a liveness probe that can be throttled
-    // is a liveness probe that lies during an incident.
-    .use("*", except("/health", rateLimit(deps, POLICIES.authenticated)))
+    // Every policy is keyed by userId, so this sits below the gate. No
+    // `/health` exemption needed: it's registered above the gate, so a
+    // request to it never reaches this line (__tests__/openapi.test.ts
+    // asserts the ordering).
+    .use("*", rateLimit(deps, POLICIES.authenticated))
     // Costlier actions get their own budget on top of the general one.
-    .use("/accounts/:id/sync", rateLimit(deps, POLICIES.import))
+    // import is keyed per account, not per user: the 60s sync cooldown
+    // (SYNC_COOLDOWN_SECONDS) is already per account, and a user syncing
+    // several tracked accounts must not have the first ones spend the
+    // budget the last one needs.
+    .use(
+      "/accounts/:id/sync",
+      rateLimit(deps, POLICIES.import, (c) => `${c.get("userId")}:${c.req.param("id")}`),
+    )
     .use("/games/:id/analyze", rateLimit(deps, POLICIES.expensive))
     .route("/accounts", accountsRoutes(deps))
     .route("/games", gamesRoutes(deps))

--- a/apps/web/src/app-shell/user-menu.tsx
+++ b/apps/web/src/app-shell/user-menu.tsx
@@ -23,17 +23,8 @@ const USER_MENU_COPY = {
   signingOut: msg`Signing out…`,
 } as const;
 
-/**
- * The account entry point in the shell: who is signed in, the way into
- * Settings, and the way out.
- *
- * Managing the account happens behind the Settings link, not in here — a
- * popover you can rename yourself in is a popover you rename yourself in
- * by accident. What stays is what has to be one click: signing out.
- *
- * Reads the same session query the route guard already resolved, so there
- * is no loading state to render.
- */
+/** Who is signed in, the way into Settings, and the way out. Reads the
+ * session query the route guard already resolved — no loading state. */
 export function UserMenu() {
   const { i18n } = useLingui();
   const navigate = useNavigate();
@@ -54,9 +45,6 @@ export function UserMenu() {
           />
         }
       >
-        {/* The person's own picture is the affordance. A generic user
-            glyph reads as "account" to whoever built the page and as
-            nothing in particular to whoever is looking for themselves. */}
         <UserAvatar user={user} size="sm" />
       </PopoverTrigger>
 

--- a/apps/web/src/app-shell/user-menu.tsx
+++ b/apps/web/src/app-shell/user-menu.tsx
@@ -9,19 +9,31 @@ import {
   PopoverTrigger,
 } from "@velachess/ui/components/popover";
 import { Separator } from "@velachess/ui/components/separator";
-import { UserRoundIcon } from "@velachess/ui/icons";
+import { SettingsIcon } from "@velachess/ui/icons";
 
 import { useSignOut } from "../auth/sign-out/use-sign-out.ts";
 import { sessionQuery } from "../auth/session.ts";
+import { UserAvatar } from "../auth/user-avatar.tsx";
 import { useQuery } from "../shared/libs/query/index.ts";
 
 const USER_MENU_COPY = {
   open: msg`Account`,
+  settings: msg`Settings`,
   signOut: msg`Sign out`,
   signingOut: msg`Signing out…`,
 } as const;
 
-/** Reads the same session query the route guard already resolved — no loading state needed here. */
+/**
+ * The account entry point in the shell: who is signed in, the way into
+ * Settings, and the way out.
+ *
+ * Managing the account happens behind the Settings link, not in here — a
+ * popover you can rename yourself in is a popover you rename yourself in
+ * by accident. What stays is what has to be one click: signing out.
+ *
+ * Reads the same session query the route guard already resolved, so there
+ * is no loading state to render.
+ */
 export function UserMenu() {
   const { i18n } = useLingui();
   const navigate = useNavigate();
@@ -34,17 +46,41 @@ export function UserMenu() {
     <Popover>
       <PopoverTrigger
         render={
-          <Button variant="ghost" size="icon" aria-label={i18n._(USER_MENU_COPY.open)} />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={i18n._(USER_MENU_COPY.open)}
+            className="rounded-full"
+          />
         }
       >
-        <UserRoundIcon />
+        {/* The person's own picture is the affordance. A generic user
+            glyph reads as "account" to whoever built the page and as
+            nothing in particular to whoever is looking for themselves. */}
+        <UserAvatar user={user} size="sm" />
       </PopoverTrigger>
 
       <PopoverContent align="end" className="w-56">
-        <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium">{user.name}</span>
-          <span className="text-muted-foreground truncate text-xs">{user.email}</span>
+        <div className="flex items-center gap-2">
+          <UserAvatar user={user} />
+          <div className="flex min-w-0 flex-col">
+            <span className="truncate text-sm font-medium">{user.name}</span>
+            <span className="text-muted-foreground truncate text-xs">{user.email}</span>
+          </div>
         </div>
+
+        <Separator className="my-3" />
+
+        <Button
+          variant="ghost"
+          className="w-full justify-start"
+          onClick={async () => {
+            await navigate({ to: "/settings/account" });
+          }}
+        >
+          <SettingsIcon />
+          {i18n._(USER_MENU_COPY.settings)}
+        </Button>
 
         <Separator className="my-3" />
 

--- a/apps/web/src/auth/__tests__/auth.test.tsx
+++ b/apps/web/src/auth/__tests__/auth.test.tsx
@@ -28,7 +28,7 @@ import {
 async function signIn(user: Awaited<ReturnType<typeof renderApp>>["user"]) {
   await user.type(screen.getByLabelText("Email"), TEST_USER.email);
   await user.type(screen.getByLabelText("Password"), TEST_PASSWORD);
-  await user.click(screen.getByRole("button", { name: "Login" }));
+  await user.click(screen.getByRole("button", { name: "Sign in" }));
 }
 
 describe("the wall", () => {
@@ -38,7 +38,7 @@ describe("the wall", () => {
     const { router } = await renderApp({ path: "/games" });
 
     expect(router.state.location.pathname).toBe("/login");
-    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
     // Where they were going, kept for after they sign in — the whole
     // location, search included, not just the path.
     expect(router.state.location.search).toMatchObject({
@@ -115,7 +115,7 @@ describe("the wall", () => {
     const { router } = await renderApp({ path: "/games" });
 
     expect(router.state.location.pathname).toBe("/login");
-    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
   });
 });
 
@@ -148,7 +148,7 @@ describe("signing in", () => {
     const { router, user } = await renderApp({ path: "/login" });
     await user.type(screen.getByLabelText("Email"), TEST_USER.email);
     await user.type(screen.getByLabelText("Password"), "not-the-password");
-    await user.click(screen.getByRole("button", { name: "Login" }));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Invalid email or password.",
@@ -176,11 +176,49 @@ describe("signing in", () => {
     sessionInactive();
 
     const { router, user } = await renderApp({ path: "/login" });
-    await user.click(screen.getByRole("button", { name: "Login" }));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
 
     expect(await screen.findByText("Enter your email.")).toBeInTheDocument();
     expect(screen.getByText("Enter your password.")).toBeInTheDocument();
     expect(router.state.location.pathname).toBe("/login");
+  });
+});
+
+describe("what a sign-in outcome depends on", () => {
+  it("succeeds even when the session endpoint is down — no follow-up fetch", async () => {
+    sessionInactive();
+    // The session cache is seeded from the sign-in response itself, so a
+    // broken get-session cannot make a successful sign-in look failed.
+    server.use(
+      http.get("/api/auth/get-session", () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const { router, user } = await renderApp({ path: "/login" });
+    await signIn(user);
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+  });
+
+  it("reads a 401 without Better Auth's credential code as unavailability", async () => {
+    sessionInactive();
+    // A proxy or an outage can also answer 401 — that is not proof the
+    // password was wrong, and saying so would send someone to re-type a
+    // correct one.
+    server.use(
+      http.post("/api/auth/sign-in/email", () =>
+        HttpResponse.json({ message: "upstream timeout" }, { status: 401 }),
+      ),
+    );
+
+    const { user } = await renderApp({ path: "/login" });
+    await signIn(user);
+
+    expect(
+      await screen.findByText("Couldn't reach the server. Try again in a moment."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Invalid email or password.")).not.toBeInTheDocument();
   });
 });
 
@@ -228,6 +266,6 @@ describe("a session that ends mid-visit", () => {
     await queryClient.invalidateQueries({ queryKey: ["games"] });
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/login"));
-    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/auth/__tests__/auth.test.tsx
+++ b/apps/web/src/auth/__tests__/auth.test.tsx
@@ -156,6 +156,28 @@ describe("signing in", () => {
     expect(router.state.location.pathname).toBe("/login");
   });
 
+  it("says what is wrong on a malformed email, not that the server is down", async () => {
+    sessionInactive();
+    server.use(
+      http.post("/api/auth/sign-in/email", () =>
+        HttpResponse.json(
+          { code: "INVALID_EMAIL", message: "Invalid email" },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const { user } = await renderApp({ path: "/login" });
+    await signIn(user);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Invalid email or password.",
+    );
+    expect(
+      screen.queryByText("Couldn't reach the server. Try again in a moment."),
+    ).not.toBeInTheDocument();
+  });
+
   it("tells a failed request apart from a rejected password", async () => {
     sessionInactive();
     server.use(

--- a/apps/web/src/auth/__tests__/auth.test.tsx
+++ b/apps/web/src/auth/__tests__/auth.test.tsx
@@ -28,7 +28,7 @@ import {
 async function signIn(user: Awaited<ReturnType<typeof renderApp>>["user"]) {
   await user.type(screen.getByLabelText("Email"), TEST_USER.email);
   await user.type(screen.getByLabelText("Password"), TEST_PASSWORD);
-  await user.click(screen.getByRole("button", { name: "Sign in" }));
+  await user.click(screen.getByRole("button", { name: "Login" }));
 }
 
 describe("the wall", () => {
@@ -38,7 +38,7 @@ describe("the wall", () => {
     const { router } = await renderApp({ path: "/games" });
 
     expect(router.state.location.pathname).toBe("/login");
-    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
     // Where they were going, kept for after they sign in — the whole
     // location, search included, not just the path.
     expect(router.state.location.search).toMatchObject({
@@ -115,7 +115,7 @@ describe("the wall", () => {
     const { router } = await renderApp({ path: "/games" });
 
     expect(router.state.location.pathname).toBe("/login");
-    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
   });
 });
 
@@ -148,7 +148,7 @@ describe("signing in", () => {
     const { router, user } = await renderApp({ path: "/login" });
     await user.type(screen.getByLabelText("Email"), TEST_USER.email);
     await user.type(screen.getByLabelText("Password"), "not-the-password");
-    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await user.click(screen.getByRole("button", { name: "Login" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Invalid email or password.",
@@ -176,7 +176,7 @@ describe("signing in", () => {
     sessionInactive();
 
     const { router, user } = await renderApp({ path: "/login" });
-    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await user.click(screen.getByRole("button", { name: "Login" }));
 
     expect(await screen.findByText("Enter your email.")).toBeInTheDocument();
     expect(screen.getByText("Enter your password.")).toBeInTheDocument();
@@ -228,6 +228,6 @@ describe("a session that ends mid-visit", () => {
     await queryClient.invalidateQueries({ queryKey: ["games"] });
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/login"));
-    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/auth/__tests__/google-sign-in.test.tsx
+++ b/apps/web/src/auth/__tests__/google-sign-in.test.tsx
@@ -28,9 +28,9 @@ describe("the Google button", () => {
     // without credentials does.
     await renderApp({ path: "/login" });
 
-    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Login with Google" }),
+      screen.queryByRole("button", { name: "Continue with Google" }),
     ).not.toBeInTheDocument();
     // And the password form is untouched — the two methods are
     // independent, which is the whole reason the flag exists.
@@ -44,10 +44,38 @@ describe("the Google button", () => {
     await renderApp({ path: "/login" });
 
     expect(
-      await screen.findByRole("button", { name: "Login with Google" }),
+      await screen.findByRole("button", { name: "Continue with Google" }),
     ).toBeInTheDocument();
     // Both methods, not one replacing the other.
-    expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+  });
+
+  it("never assumes the visitor is returning — Google is also the first door in", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    await renderApp({ path: "/login" });
+
+    // The provider button creates the account on first use (implicit
+    // sign-up), so the copy stays neutral for both entry cases…
+    expect(await screen.findByText("Continue to VelaChess")).toBeInTheDocument();
+    expect(
+      screen.getByText("Continue with Google or sign in with your account credentials."),
+    ).toBeInTheDocument();
+    // …and never promises an email registration that does not exist.
+    expect(screen.queryByText(/sign up|create account/i)).not.toBeInTheDocument();
+  });
+
+  it("mentions only credentials on a password-only instance", async () => {
+    sessionInactive();
+
+    await renderApp({ path: "/login" });
+
+    expect(await screen.findByText("Continue to VelaChess")).toBeInTheDocument();
+    expect(
+      screen.getByText("Sign in with your account credentials."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Google/)).not.toBeInTheDocument();
   });
 
   it("asks the server to start the flow, and never handles OAuth itself", async () => {
@@ -63,7 +91,7 @@ describe("the Google button", () => {
     );
 
     const { user } = await renderApp({ path: "/login?redirect=%2Fgames" });
-    await user.click(await screen.findByRole("button", { name: "Login with Google" }));
+    await user.click(await screen.findByRole("button", { name: "Continue with Google" }));
 
     await waitFor(() => expect(body).toBeDefined());
     // The provider, and where the person was headed — nothing else. No
@@ -71,6 +99,11 @@ describe("the Google button", () => {
     // client secret that reached this request would be a leak.
     expect(body).toMatchObject({ provider: "google", callbackURL: "/games" });
     expect(JSON.stringify(body)).not.toContain("secret");
+    // The failure leg keeps the destination too: cancelling consent must
+    // not cost the person where they were going.
+    expect(body).toMatchObject({
+      errorCallbackURL: "/login?redirect=%2Fgames",
+    });
   });
 
   it("carries the interrupted destination through, like the password form does", async () => {
@@ -86,7 +119,7 @@ describe("the Google button", () => {
     );
 
     const { user } = await renderApp({ path: "/login" });
-    await user.click(await screen.findByRole("button", { name: "Login with Google" }));
+    await user.click(await screen.findByRole("button", { name: "Continue with Google" }));
 
     // No `redirect` in the URL means the app's front door.
     await waitFor(() => expect(body).toMatchObject({ callbackURL: "/" }));
@@ -134,7 +167,7 @@ describe("coming back from Google without a session", () => {
 
     await user.type(screen.getByLabelText("Email"), TEST_USER.email);
     await user.type(screen.getByLabelText("Password"), TEST_PASSWORD);
-    await user.click(screen.getByRole("button", { name: "Login" }));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
   });
@@ -153,7 +186,7 @@ describe("when the sign-in-methods lookup fails", () => {
 
     // A login screen that renders nothing because a capability lookup
     // failed is worse than one that offers the password form.
-    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/auth/__tests__/google-sign-in.test.tsx
+++ b/apps/web/src/auth/__tests__/google-sign-in.test.tsx
@@ -137,6 +137,22 @@ describe("coming back from Google without a session", () => {
     expect(await screen.findByText("Google sign-in was cancelled.")).toBeInTheDocument();
   });
 
+  it("points to the password form when the email is already a password account", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    // account_not_linked is Better Auth's code for an existing password
+    // account at that email — retrying Google never helps, so it must not
+    // get the generic "didn't complete, try again" copy.
+    await renderApp({ path: "/login?error=account_not_linked" });
+
+    expect(
+      await screen.findByText(
+        "An account already exists with that email. Sign in with your password instead.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("says something went wrong for every other reason, without echoing the code", async () => {
     sessionInactive();
     signInMethodsAre({ google: true });

--- a/apps/web/src/auth/__tests__/google-sign-in.test.tsx
+++ b/apps/web/src/auth/__tests__/google-sign-in.test.tsx
@@ -28,9 +28,9 @@ describe("the Google button", () => {
     // without credentials does.
     await renderApp({ path: "/login" });
 
-    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Continue with Google" }),
+      screen.queryByRole("button", { name: "Login with Google" }),
     ).not.toBeInTheDocument();
     // And the password form is untouched — the two methods are
     // independent, which is the whole reason the flag exists.
@@ -44,10 +44,10 @@ describe("the Google button", () => {
     await renderApp({ path: "/login" });
 
     expect(
-      await screen.findByRole("button", { name: "Continue with Google" }),
+      await screen.findByRole("button", { name: "Login with Google" }),
     ).toBeInTheDocument();
     // Both methods, not one replacing the other.
-    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
   });
 
   it("asks the server to start the flow, and never handles OAuth itself", async () => {
@@ -63,7 +63,7 @@ describe("the Google button", () => {
     );
 
     const { user } = await renderApp({ path: "/login?redirect=%2Fgames" });
-    await user.click(await screen.findByRole("button", { name: "Continue with Google" }));
+    await user.click(await screen.findByRole("button", { name: "Login with Google" }));
 
     await waitFor(() => expect(body).toBeDefined());
     // The provider, and where the person was headed — nothing else. No
@@ -86,7 +86,7 @@ describe("the Google button", () => {
     );
 
     const { user } = await renderApp({ path: "/login" });
-    await user.click(await screen.findByRole("button", { name: "Continue with Google" }));
+    await user.click(await screen.findByRole("button", { name: "Login with Google" }));
 
     // No `redirect` in the URL means the app's front door.
     await waitFor(() => expect(body).toMatchObject({ callbackURL: "/" }));
@@ -134,7 +134,7 @@ describe("coming back from Google without a session", () => {
 
     await user.type(screen.getByLabelText("Email"), TEST_USER.email);
     await user.type(screen.getByLabelText("Password"), TEST_PASSWORD);
-    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    await user.click(screen.getByRole("button", { name: "Login" }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
   });
@@ -153,7 +153,7 @@ describe("when the sign-in-methods lookup fails", () => {
 
     // A login screen that renders nothing because a capability lookup
     // failed is worse than one that offers the password form.
-    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Login" })).toBeInTheDocument();
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/auth/__tests__/google-sign-in.test.tsx
+++ b/apps/web/src/auth/__tests__/google-sign-in.test.tsx
@@ -1,0 +1,159 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+
+import { renderApp } from "../../test/render.tsx";
+import { server } from "../../test/server.ts";
+import {
+  sessionInactive,
+  signInMethodsAre,
+  TEST_PASSWORD,
+  TEST_USER,
+} from "../../test/handlers/auth.ts";
+
+/**
+ * Signing in with Google, from the screen's side of the flow.
+ *
+ * The redirect itself is not testable here and should not be faked: jsdom
+ * does not navigate, and a stubbed `location.assign` would prove only that
+ * the stub was called. What the screen genuinely owns is everything around
+ * the redirect — whether the button exists at all, what it asks the server
+ * for, and what the person sees when they come back without a session.
+ */
+
+describe("the Google button", () => {
+  it("is absent on an instance with no Google credentials", async () => {
+    sessionInactive();
+    // The default: `GET /config` reports google: false, as a self-host
+    // without credentials does.
+    await renderApp({ path: "/login" });
+
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Continue with Google" }),
+    ).not.toBeInTheDocument();
+    // And the password form is untouched — the two methods are
+    // independent, which is the whole reason the flag exists.
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  });
+
+  it("appears once the server says the provider is configured", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    await renderApp({ path: "/login" });
+
+    expect(
+      await screen.findByRole("button", { name: "Continue with Google" }),
+    ).toBeInTheDocument();
+    // Both methods, not one replacing the other.
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+  });
+
+  it("asks the server to start the flow, and never handles OAuth itself", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post("/api/auth/sign-in/social", async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ url: "https://accounts.google.com/o/oauth2/v2/auth" });
+      }),
+    );
+
+    const { user } = await renderApp({ path: "/login?redirect=%2Fgames" });
+    await user.click(await screen.findByRole("button", { name: "Continue with Google" }));
+
+    await waitFor(() => expect(body).toBeDefined());
+    // The provider, and where the person was headed — nothing else. No
+    // client id, no scopes, no state: those are the server's, and a
+    // client secret that reached this request would be a leak.
+    expect(body).toMatchObject({ provider: "google", callbackURL: "/games" });
+    expect(JSON.stringify(body)).not.toContain("secret");
+  });
+
+  it("carries the interrupted destination through, like the password form does", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post("/api/auth/sign-in/social", async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ url: "https://accounts.google.com" });
+      }),
+    );
+
+    const { user } = await renderApp({ path: "/login" });
+    await user.click(await screen.findByRole("button", { name: "Continue with Google" }));
+
+    // No `redirect` in the URL means the app's front door.
+    await waitFor(() => expect(body).toMatchObject({ callbackURL: "/" }));
+  });
+});
+
+describe("coming back from Google without a session", () => {
+  it("says the attempt was cancelled when the person refused consent", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    // `access_denied` is OAuth's own code for "the person said no".
+    await renderApp({ path: "/login?error=access_denied" });
+
+    expect(await screen.findByText("Google sign-in was cancelled.")).toBeInTheDocument();
+  });
+
+  it("says something went wrong for every other reason, without echoing the code", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    await renderApp({ path: "/login?error=please_restart_the_process" });
+
+    expect(
+      await screen.findByText("Google sign-in didn't complete. Try again."),
+    ).toBeInTheDocument();
+    // The provider's code is written for a log, not for a person.
+    expect(screen.queryByText(/please_restart_the_process/)).not.toBeInTheDocument();
+  });
+
+  it("still explains itself if the provider was switched off meanwhile", async () => {
+    sessionInactive();
+    // No Google button on this render — the error must not vanish with it,
+    // or the person is back at a login screen with no idea why.
+    await renderApp({ path: "/login?error=access_denied" });
+
+    expect(await screen.findByText("Google sign-in was cancelled.")).toBeInTheDocument();
+  });
+
+  it("leaves the password form usable", async () => {
+    sessionInactive();
+    signInMethodsAre({ google: true });
+
+    const { router, user } = await renderApp({ path: "/login?error=access_denied" });
+
+    await user.type(screen.getByLabelText("Email"), TEST_USER.email);
+    await user.type(screen.getByLabelText("Password"), TEST_PASSWORD);
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+  });
+});
+
+describe("when the sign-in-methods lookup fails", () => {
+  it("still offers the method every instance has", async () => {
+    sessionInactive();
+    server.use(
+      http.get("/api/config", () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 }),
+      ),
+    );
+
+    await renderApp({ path: "/login" });
+
+    // A login screen that renders nothing because a capability lookup
+    // failed is worse than one that offers the password form.
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/auth/client.ts
+++ b/apps/web/src/auth/client.ts
@@ -22,4 +22,8 @@ export interface SessionUser {
   id: string;
   email: string;
   name: string;
+  /** Better Auth's `user.image` — the provider's picture, for accounts
+   * that came from one. `null` for an email/password account, which is
+   * why every consumer needs a fallback rather than an `<img>`. */
+  image: string | null;
 }

--- a/apps/web/src/auth/session.ts
+++ b/apps/web/src/auth/session.ts
@@ -19,8 +19,11 @@ export async function fetchSession(): Promise<SessionUser | null> {
   }
 
   if (!data?.user) return null;
-  const { id, email, name } = data.user;
-  return { id, email, name };
+  const { id, email, name, image } = data.user;
+  // `image` is optional in Better Auth's type and absent for a
+  // password-only account; normalized to null so consumers branch on one
+  // shape instead of two.
+  return { id, email, name, image: image ?? null };
 }
 
 export const sessionQuery = queryOptions({

--- a/apps/web/src/auth/session.ts
+++ b/apps/web/src/auth/session.ts
@@ -20,9 +20,6 @@ export async function fetchSession(): Promise<SessionUser | null> {
 
   if (!data?.user) return null;
   const { id, email, name, image } = data.user;
-  // `image` is optional in Better Auth's type and absent for a
-  // password-only account; normalized to null so consumers branch on one
-  // shape instead of two.
   return { id, email, name, image: image ?? null };
 }
 

--- a/apps/web/src/auth/session.ts
+++ b/apps/web/src/auth/session.ts
@@ -10,7 +10,7 @@ export const sessionQueryKey = ["auth", "session"] as const;
  * Better Auth resolves rather than throws: a 401 means "answered, nobody";
  * any other error means the question was never actually answered.
  */
-export async function fetchSession(): Promise<SessionUser | null> {
+async function fetchSession(): Promise<SessionUser | null> {
   const { data, error } = await authClient.getSession();
 
   if (error) {

--- a/apps/web/src/auth/sign-in-methods.ts
+++ b/apps/web/src/auth/sign-in-methods.ts
@@ -1,12 +1,5 @@
-/**
- * What this deployment lets people sign in with.
- *
- * A self-hosted instance with no Google credentials must not be offered a
- * "Login with Google" button — it would redirect to an error and there
- * is nothing the person could do about it. The server answers this at
- * `GET /config`, which is public precisely because the question is asked
- * before anyone has a session.
- */
+/** What this deployment lets people sign in with — `GET /config`,
+ * public because it is asked before anyone has a session. */
 
 import { api, parseResponse } from "../shared/api/client.ts";
 import { queryOptions } from "../shared/libs/query/index.ts";
@@ -16,11 +9,7 @@ export interface SignInMethods {
   google: boolean;
 }
 
-/**
- * Password only. Used when the request fails — a login screen that renders
- * nothing because a capability lookup 500'd is worse than one that offers
- * the method every instance has.
- */
+// On failure, offer the method every instance has.
 const FALLBACK: SignInMethods = { password: true, google: false };
 
 export const signInMethodsQuery = queryOptions({
@@ -33,7 +22,5 @@ export const signInMethodsQuery = queryOptions({
       return FALLBACK;
     }
   },
-  // Capabilities change when the server is redeployed, not while someone
-  // is looking at the login form.
   staleTime: Infinity,
 });

--- a/apps/web/src/auth/sign-in-methods.ts
+++ b/apps/web/src/auth/sign-in-methods.ts
@@ -1,0 +1,39 @@
+/**
+ * What this deployment lets people sign in with.
+ *
+ * A self-hosted instance with no Google credentials must not be offered a
+ * "Continue with Google" button — it would redirect to an error and there
+ * is nothing the person could do about it. The server answers this at
+ * `GET /config`, which is public precisely because the question is asked
+ * before anyone has a session.
+ */
+
+import { api, parseResponse } from "../shared/api/client.ts";
+import { queryOptions } from "../shared/libs/query/index.ts";
+
+export interface SignInMethods {
+  password: boolean;
+  google: boolean;
+}
+
+/**
+ * Password only. Used when the request fails — a login screen that renders
+ * nothing because a capability lookup 500'd is worse than one that offers
+ * the method every instance has.
+ */
+const FALLBACK: SignInMethods = { password: true, google: false };
+
+export const signInMethodsQuery = queryOptions({
+  queryKey: ["auth", "sign-in-methods"] as const,
+  queryFn: async (): Promise<SignInMethods> => {
+    try {
+      const { signInMethods } = await parseResponse(api.config.$get());
+      return signInMethods;
+    } catch {
+      return FALLBACK;
+    }
+  },
+  // Capabilities change when the server is redeployed, not while someone
+  // is looking at the login form.
+  staleTime: Infinity,
+});

--- a/apps/web/src/auth/sign-in-methods.ts
+++ b/apps/web/src/auth/sign-in-methods.ts
@@ -2,7 +2,7 @@
  * What this deployment lets people sign in with.
  *
  * A self-hosted instance with no Google credentials must not be offered a
- * "Continue with Google" button — it would redirect to an error and there
+ * "Login with Google" button — it would redirect to an error and there
  * is nothing the person could do about it. The server answers this at
  * `GET /config`, which is public precisely because the question is asked
  * before anyone has a session.

--- a/apps/web/src/auth/sign-in/sign-in-screen.tsx
+++ b/apps/web/src/auth/sign-in/sign-in-screen.tsx
@@ -124,7 +124,7 @@ export function SignInScreen({
     setGoogleFailed(false);
     setGooglePending(true);
     try {
-      await signInWithGoogle({ callbackURL: redirect ?? "/", redirect });
+      await signInWithGoogle({ successURL: redirect ?? "/", redirect });
       // No `finally`: on success the browser is navigating away, and
       // re-enabling the button here would let a click race that navigation
       // and start a second flow before it lands.

--- a/apps/web/src/auth/sign-in/sign-in-screen.tsx
+++ b/apps/web/src/auth/sign-in/sign-in-screen.tsx
@@ -29,20 +29,25 @@ import { signInMethodsQuery } from "../sign-in-methods.ts";
 import { useQuery } from "../../shared/libs/query/index.ts";
 import { z } from "../../shared/libs/zod.ts";
 
+// shadcn's login block wording, kept as-is where the control exists.
+// The description is the one line that varies by deployment: the block's
+// "Login with your Apple or Google account" names providers, so it can
+// only name the ones this instance actually offers.
 const SIGN_IN_COPY = {
   title: msg`Welcome back`,
-  description: msg`Sign in to your VelaChess instance.`,
+  descriptionGoogle: msg`Login with your Google account`,
+  descriptionPassword: msg`Enter your email below to login to your account`,
   email: msg`Email`,
   password: msg`Password`,
-  submit: msg`Sign in`,
-  submitting: msg`Signing in…`,
+  submit: msg`Login`,
+  submitting: msg`Logging in…`,
   invalidCredentials: msg`Invalid email or password.`,
   unavailable: msg`Couldn't reach the server. Try again in a moment.`,
   emailRequired: msg`Enter your email.`,
   emailInvalid: msg`That doesn't look like an email address.`,
   passwordRequired: msg`Enter your password.`,
-  google: msg`Continue with Google`,
-  or: msg`or`,
+  google: msg`Login with Google`,
+  or: msg`Or continue with`,
   googleCancelled: msg`Google sign-in was cancelled.`,
   googleFailed: msg`Google sign-in didn't complete. Try again.`,
 } as const;
@@ -169,7 +174,13 @@ export function SignInScreen({
           <Card>
             <CardHeader className="text-center">
               <CardTitle className="text-xl">{i18n._(SIGN_IN_COPY.title)}</CardTitle>
-              <CardDescription>{i18n._(SIGN_IN_COPY.description)}</CardDescription>
+              <CardDescription>
+                {i18n._(
+                  methods?.google
+                    ? SIGN_IN_COPY.descriptionGoogle
+                    : SIGN_IN_COPY.descriptionPassword,
+                )}
+              </CardDescription>
             </CardHeader>
 
             <CardContent>
@@ -210,7 +221,9 @@ export function SignInScreen({
                         </Button>
                       </Field>
 
-                      <FieldSeparator>{i18n._(SIGN_IN_COPY.or)}</FieldSeparator>
+                      <FieldSeparator className="*:data-[slot=field-separator-content]:bg-card">
+                        {i18n._(SIGN_IN_COPY.or)}
+                      </FieldSeparator>
                     </>
                   )}
 
@@ -239,7 +252,7 @@ export function SignInScreen({
                             name={field.name}
                             type="email"
                             autoComplete="email"
-                            placeholder="you@example.com"
+                            placeholder="m@example.com"
                             aria-invalid={isInvalid}
                             value={field.state.value}
                             onBlur={field.handleBlur}

--- a/apps/web/src/auth/sign-in/sign-in-screen.tsx
+++ b/apps/web/src/auth/sign-in/sign-in-screen.tsx
@@ -2,6 +2,7 @@ import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 import { useForm } from "@tanstack/react-form";
 import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 
 import { Button } from "@velachess/ui/components/button";
 import {
@@ -16,12 +17,16 @@ import {
   FieldError,
   FieldGroup,
   FieldLabel,
+  FieldSeparator,
 } from "@velachess/ui/components/field";
 import { Input } from "@velachess/ui/components/input";
-import { VelaChessMark } from "@velachess/ui/icons";
+import { GoogleIcon, VelaChessMark } from "@velachess/ui/icons";
 
 import { signInFailureOf, type SignInFailure } from "./sign-in.ts";
+import { signInWithGoogle } from "./social.ts";
 import { useSignIn } from "./use-sign-in.ts";
+import { signInMethodsQuery } from "../sign-in-methods.ts";
+import { useQuery } from "../../shared/libs/query/index.ts";
 import { z } from "../../shared/libs/zod.ts";
 
 const SIGN_IN_COPY = {
@@ -36,6 +41,10 @@ const SIGN_IN_COPY = {
   emailRequired: msg`Enter your email.`,
   emailInvalid: msg`That doesn't look like an email address.`,
   passwordRequired: msg`Enter your password.`,
+  google: msg`Continue with Google`,
+  or: msg`or`,
+  googleCancelled: msg`Google sign-in was cancelled.`,
+  googleFailed: msg`Google sign-in didn't complete. Try again.`,
 } as const;
 
 const FAILURE_COPY: Record<
@@ -47,26 +56,52 @@ const FAILURE_COPY: Record<
 };
 
 /**
+ * Two ways a Google attempt comes back here, and they are not the same
+ * event: the person said no, or something broke. Better Auth puts the
+ * reason in `?error=`; `access_denied` is OAuth's own code for a refused
+ * consent screen, and everything else — a stale state, a provider
+ * timeout, a misconfigured client — reads as a failure worth retrying.
+ *
+ * The provider's raw code is never rendered. It is written for whoever
+ * reads a log, not for someone who just wanted to sign in.
+ */
+function oauthErrorCopy(code: string) {
+  return code === "access_denied"
+    ? SIGN_IN_COPY.googleCancelled
+    : SIGN_IN_COPY.googleFailed;
+}
+
+/**
  * The one screen reachable without a session.
  *
  * Laid out as shadcn's login block: a muted full-height page, the brand
  * lockup centred above a `max-w-sm` card, a centred card header, and the
  * form as one `FieldGroup`.
  *
- * What the block ships that this build does not: OAuth buttons and their
- * separator, "forgot your password", and a sign-up link. None of the
- * three exists on the server — `/auth/sign-up/email` answers 400 and the
- * first user is provisioned at startup (docs/how-to/self-host.md) — and
- * a control that cannot do anything is worse than an absent one.
+ * Which methods appear is the server's answer, not this file's guess:
+ * `signInMethodsQuery` reads `GET /config`, so a self-host without Google
+ * credentials renders no Google button. A control that cannot do anything
+ * is worse than an absent one — the same reason there is still no
+ * "forgot your password" or sign-up link: `/auth/sign-up/email` answers
+ * 400 by design and password recovery needs an SMTP dependency this build
+ * does not have. Public sign-up, where it is wanted, is Google's path.
  *
  * Where it lands afterwards is the router's business, not this form's:
  * `redirect` carries where the person was headed before the guard
- * intervened.
+ * intervened, and it is the same destination for both methods.
  */
-export function SignInScreen({ redirect }: { redirect?: string }) {
+export function SignInScreen({
+  redirect,
+  oauthError,
+}: {
+  redirect?: string;
+  /** `?error=` as Better Auth returned it after a Google attempt. */
+  oauthError?: string;
+}) {
   const { i18n } = useLingui();
   const navigate = useNavigate();
   const signIn = useSignIn();
+  const { data: methods } = useQuery(signInMethodsQuery);
 
   const form = useForm({
     defaultValues: { email: "", password: "" },
@@ -88,6 +123,29 @@ export function SignInScreen({ redirect }: { redirect?: string }) {
   });
 
   const failure = signIn.isError ? signInFailureOf(signIn.error) : null;
+  const [googlePending, setGooglePending] = useState(false);
+  const [googleFailed, setGoogleFailed] = useState(false);
+
+  // Two sources, one message: a code Better Auth handed back through the
+  // URL, or a request that never reached the provider at all.
+  const oauthMessage = googleFailed
+    ? SIGN_IN_COPY.googleFailed
+    : oauthError
+      ? oauthErrorCopy(oauthError)
+      : null;
+
+  const startGoogle = async () => {
+    setGoogleFailed(false);
+    setGooglePending(true);
+    try {
+      await signInWithGoogle({ callbackURL: redirect ?? "/" });
+      // Reached only if the browser did not navigate away.
+    } catch {
+      setGoogleFailed(true);
+    } finally {
+      setGooglePending(false);
+    }
+  };
 
   return (
     <main className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
@@ -122,6 +180,40 @@ export function SignInScreen({ redirect }: { redirect?: string }) {
                 }}
               >
                 <FieldGroup>
+                  {/* Rendered whether or not the button below is, and
+                      that is the point: if the provider was switched off
+                      between the redirect out and the return, the person
+                      still gets told why they are back here instead of
+                      inside the app. */}
+                  {oauthMessage !== null && (
+                    <Field>
+                      <FieldError>{i18n._(oauthMessage)}</FieldError>
+                    </Field>
+                  )}
+
+                  {/* Above the password fields, because it is the faster
+                      path for anyone who has it, and because a provider
+                      button below a submit button reads as a second
+                      submit. Rendered only where the server says the
+                      provider exists. */}
+                  {methods?.google && (
+                    <>
+                      <Field>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={googlePending || signIn.isPending}
+                          onClick={() => void startGoogle()}
+                        >
+                          <GoogleIcon className="size-4" />
+                          {i18n._(SIGN_IN_COPY.google)}
+                        </Button>
+                      </Field>
+
+                      <FieldSeparator>{i18n._(SIGN_IN_COPY.or)}</FieldSeparator>
+                    </>
+                  )}
+
                   <form.Field
                     name="email"
                     validators={{

--- a/apps/web/src/auth/sign-in/sign-in-screen.tsx
+++ b/apps/web/src/auth/sign-in/sign-in-screen.tsx
@@ -49,6 +49,7 @@ const SIGN_IN_COPY = {
   or: msg`Or continue with`,
   googleCancelled: msg`Google sign-in was cancelled.`,
   googleFailed: msg`Google sign-in didn't complete. Try again.`,
+  googleAccountNotLinked: msg`An account already exists with that email. Sign in with your password instead.`,
 } as const;
 
 const FAILURE_COPY: Record<
@@ -59,12 +60,18 @@ const FAILURE_COPY: Record<
   unavailable: SIGN_IN_COPY.unavailable,
 };
 
-// access_denied is OAuth's "the person said no"; everything else reads
-// as a retryable failure. The raw code is never rendered.
+/** OAuth's own "the person said no". */
+const OAUTH_ERROR_ACCESS_DENIED = "access_denied";
+/** Better Auth refusing to attach Google to an existing password account —
+ * retrying never succeeds, so it gets its own copy. */
+const OAUTH_ERROR_ACCOUNT_NOT_LINKED = "account_not_linked";
+
+// Everything else reads as a retryable failure. The raw code is never
+// rendered.
 function oauthErrorCopy(code: string) {
-  return code === "access_denied"
-    ? SIGN_IN_COPY.googleCancelled
-    : SIGN_IN_COPY.googleFailed;
+  if (code === OAUTH_ERROR_ACCESS_DENIED) return SIGN_IN_COPY.googleCancelled;
+  if (code === OAUTH_ERROR_ACCOUNT_NOT_LINKED) return SIGN_IN_COPY.googleAccountNotLinked;
+  return SIGN_IN_COPY.googleFailed;
 }
 
 /**
@@ -118,9 +125,11 @@ export function SignInScreen({
     setGooglePending(true);
     try {
       await signInWithGoogle({ callbackURL: redirect ?? "/", redirect });
+      // No `finally`: on success the browser is navigating away, and
+      // re-enabling the button here would let a click race that navigation
+      // and start a second flow before it lands.
     } catch {
       setGoogleFailed(true);
-    } finally {
       setGooglePending(false);
     }
   };

--- a/apps/web/src/auth/sign-in/sign-in-screen.tsx
+++ b/apps/web/src/auth/sign-in/sign-in-screen.tsx
@@ -29,24 +29,23 @@ import { signInMethodsQuery } from "../sign-in-methods.ts";
 import { useQuery } from "../../shared/libs/query/index.ts";
 import { z } from "../../shared/libs/zod.ts";
 
-// shadcn's login block wording, kept as-is where the control exists.
-// The description is the one line that varies by deployment: the block's
-// "Login with your Apple or Google account" names providers, so it can
-// only name the ones this instance actually offers.
+// Neutral copy: with Google enabled, the provider button also creates
+// the account on first use — never assume the visitor is returning, and
+// never promise email registration (it does not exist).
 const SIGN_IN_COPY = {
-  title: msg`Welcome back`,
-  descriptionGoogle: msg`Login with your Google account`,
-  descriptionPassword: msg`Enter your email below to login to your account`,
+  title: msg`Continue to VelaChess`,
+  descriptionGoogle: msg`Continue with Google or sign in with your account credentials.`,
+  descriptionPassword: msg`Sign in with your account credentials.`,
   email: msg`Email`,
   password: msg`Password`,
-  submit: msg`Login`,
-  submitting: msg`Logging in…`,
+  submit: msg`Sign in`,
+  submitting: msg`Signing in…`,
   invalidCredentials: msg`Invalid email or password.`,
   unavailable: msg`Couldn't reach the server. Try again in a moment.`,
   emailRequired: msg`Enter your email.`,
   emailInvalid: msg`That doesn't look like an email address.`,
   passwordRequired: msg`Enter your password.`,
-  google: msg`Login with Google`,
+  google: msg`Continue with Google`,
   or: msg`Or continue with`,
   googleCancelled: msg`Google sign-in was cancelled.`,
   googleFailed: msg`Google sign-in didn't complete. Try again.`,
@@ -60,16 +59,8 @@ const FAILURE_COPY: Record<
   unavailable: SIGN_IN_COPY.unavailable,
 };
 
-/**
- * Two ways a Google attempt comes back here, and they are not the same
- * event: the person said no, or something broke. Better Auth puts the
- * reason in `?error=`; `access_denied` is OAuth's own code for a refused
- * consent screen, and everything else — a stale state, a provider
- * timeout, a misconfigured client — reads as a failure worth retrying.
- *
- * The provider's raw code is never rendered. It is written for whoever
- * reads a log, not for someone who just wanted to sign in.
- */
+// access_denied is OAuth's "the person said no"; everything else reads
+// as a retryable failure. The raw code is never rendered.
 function oauthErrorCopy(code: string) {
   return code === "access_denied"
     ? SIGN_IN_COPY.googleCancelled
@@ -77,23 +68,9 @@ function oauthErrorCopy(code: string) {
 }
 
 /**
- * The one screen reachable without a session.
- *
- * Laid out as shadcn's login block: a muted full-height page, the brand
- * lockup centred above a `max-w-sm` card, a centred card header, and the
- * form as one `FieldGroup`.
- *
- * Which methods appear is the server's answer, not this file's guess:
- * `signInMethodsQuery` reads `GET /config`, so a self-host without Google
- * credentials renders no Google button. A control that cannot do anything
- * is worse than an absent one — the same reason there is still no
- * "forgot your password" or sign-up link: `/auth/sign-up/email` answers
- * 400 by design and password recovery needs an SMTP dependency this build
- * does not have. Public sign-up, where it is wanted, is Google's path.
- *
- * Where it lands afterwards is the router's business, not this form's:
- * `redirect` carries where the person was headed before the guard
- * intervened, and it is the same destination for both methods.
+ * The one screen reachable without a session. Which methods appear is
+ * the server's answer (`GET /config`), so an instance without Google
+ * credentials renders no dead button.
  */
 export function SignInScreen({
   redirect,
@@ -117,9 +94,8 @@ export function SignInScreen({
           password: value.password,
         });
       } catch {
-        // Held by the mutation and rendered below. Rethrowing would end
-        // the chain in an unhandled rejection — the submit handler is
-        // the end of the chain.
+        // Held by the mutation and rendered below; rethrowing would be
+        // an unhandled rejection.
         return;
       }
 
@@ -131,8 +107,6 @@ export function SignInScreen({
   const [googlePending, setGooglePending] = useState(false);
   const [googleFailed, setGoogleFailed] = useState(false);
 
-  // Two sources, one message: a code Better Auth handed back through the
-  // URL, or a request that never reached the provider at all.
   const oauthMessage = googleFailed
     ? SIGN_IN_COPY.googleFailed
     : oauthError
@@ -143,8 +117,7 @@ export function SignInScreen({
     setGoogleFailed(false);
     setGooglePending(true);
     try {
-      await signInWithGoogle({ callbackURL: redirect ?? "/" });
-      // Reached only if the browser did not navigate away.
+      await signInWithGoogle({ callbackURL: redirect ?? "/", redirect });
     } catch {
       setGoogleFailed(true);
     } finally {
@@ -155,10 +128,6 @@ export function SignInScreen({
   return (
     <main className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
       <div className="flex w-full max-w-sm flex-col gap-6">
-        {/* The lockup, not a link: there is nowhere to go from here
-            without a session, and a dead anchor is a promise the page
-            cannot keep. `bg-brand`, not `bg-primary` — the tile is
-            decoration, not a control. */}
         <div className="flex items-center gap-2 self-center font-medium">
           <div className="flex size-6 items-center justify-center rounded-md bg-brand text-primary-foreground">
             <VelaChessMark
@@ -191,22 +160,15 @@ export function SignInScreen({
                 }}
               >
                 <FieldGroup>
-                  {/* Rendered whether or not the button below is, and
-                      that is the point: if the provider was switched off
-                      between the redirect out and the return, the person
-                      still gets told why they are back here instead of
-                      inside the app. */}
+                  {/* Rendered even when the button below is not — the
+                      person must learn why they are back here even if the
+                      provider was switched off meanwhile. */}
                   {oauthMessage !== null && (
                     <Field>
                       <FieldError>{i18n._(oauthMessage)}</FieldError>
                     </Field>
                   )}
 
-                  {/* Above the password fields, because it is the faster
-                      path for anyone who has it, and because a provider
-                      button below a submit button reads as a second
-                      submit. Rendered only where the server says the
-                      provider exists. */}
                   {methods?.google && (
                     <>
                       <Field>
@@ -293,16 +255,9 @@ export function SignInScreen({
                           />
                           <FieldError errors={field.state.meta.errors} />
 
-                          {/* A rejected sign-in, as plain inline text under
-                              the last field — no panel, no border, nothing
-                              that looks like another input.
-                              Deliberately NOT marked on the password input:
-                              the server cannot say which half was wrong, and
-                              a red ring around one field would claim it
-                              could. The server's own wording never reaches
-                              here either — it is written for developers, and
-                              "user not found" would answer the question the
-                              generic message refuses to. */}
+                          {/* Not marked on the input: the server will not
+                              say which half was wrong, so no field may
+                              claim to know. */}
                           {failure !== null && (
                             <FieldError>{i18n._(FAILURE_COPY[failure])}</FieldError>
                           )}

--- a/apps/web/src/auth/sign-in/sign-in.ts
+++ b/apps/web/src/auth/sign-in/sign-in.ts
@@ -1,9 +1,9 @@
 /**
- * Better Auth's error message is written for developers and never
- * reaches the user — echoing it would leak which half was wrong.
+ * Auth adapter: Better Auth in, `SignInFailure` out. Raw Better Auth
+ * messages never reach the user.
  */
 
-import { authClient } from "../client.ts";
+import { authClient, type SessionUser } from "../client.ts";
 import { NetworkError } from "../../shared/api/errors.ts";
 
 export interface Credentials {
@@ -12,6 +12,10 @@ export interface Credentials {
 }
 
 export type SignInFailure = "invalid-credentials" | "unavailable";
+
+// The code, not the status: a bare 401 can also be a proxy or an
+// outage, which must not read as "wrong password".
+const CREDENTIAL_REJECTION_CODES = new Set(["INVALID_EMAIL_OR_PASSWORD"]);
 
 class SignInError extends Error {
   readonly reason: SignInFailure;
@@ -23,7 +27,8 @@ class SignInError extends Error {
   }
 }
 
-export async function signIn(credentials: Credentials): Promise<void> {
+/** Resolves with the user from the sign-in response — no second round-trip. */
+export async function signIn(credentials: Credentials): Promise<SessionUser> {
   let result: Awaited<ReturnType<typeof authClient.signIn.email>>;
 
   try {
@@ -32,17 +37,19 @@ export async function signIn(credentials: Credentials): Promise<void> {
       password: credentials.password,
     });
   } catch (cause) {
-    // The request never completed — the client only rejects on transport
-    // failure, since HTTP errors come back in `error`.
+    // Transport failure; HTTP errors come back in `error`.
     throw new SignInError("unavailable", { cause });
   }
 
-  if (!result.error) return;
+  if (result.error) {
+    const rejected =
+      typeof result.error.code === "string" &&
+      CREDENTIAL_REJECTION_CODES.has(result.error.code);
+    throw new SignInError(rejected ? "invalid-credentials" : "unavailable");
+  }
 
-  // 401/403 is "these credentials are not it". Anything else — 500, a
-  // proxy in the way — is the server failing to answer the question.
-  const rejected = result.error.status === 401 || result.error.status === 403;
-  throw new SignInError(rejected ? "invalid-credentials" : "unavailable");
+  const { id, email, name, image } = result.data.user;
+  return { id, email, name, image: image ?? null };
 }
 
 export function signInFailureOf(error: unknown): SignInFailure {

--- a/apps/web/src/auth/sign-in/sign-in.ts
+++ b/apps/web/src/auth/sign-in/sign-in.ts
@@ -14,8 +14,14 @@ export interface Credentials {
 export type SignInFailure = "invalid-credentials" | "unavailable";
 
 // The code, not the status: a bare 401 can also be a proxy or an
-// outage, which must not read as "wrong password".
-const CREDENTIAL_REJECTION_CODES = new Set(["INVALID_EMAIL_OR_PASSWORD"]);
+// outage, which must not read as "wrong password". INVALID_EMAIL is
+// Better Auth's genuine 400 for a malformed address — a real answer,
+// not an outage — and gets the same copy without saying which half of
+// the form was wrong.
+const CREDENTIAL_REJECTION_CODES = new Set([
+  "INVALID_EMAIL_OR_PASSWORD",
+  "INVALID_EMAIL",
+]);
 
 class SignInError extends Error {
   readonly reason: SignInFailure;

--- a/apps/web/src/auth/sign-in/social.ts
+++ b/apps/web/src/auth/sign-in/social.ts
@@ -1,0 +1,48 @@
+/**
+ * Social sign-in: hand the browser to the provider and let Better Auth own
+ * the rest.
+ *
+ * Nothing here implements OAuth. `signIn.social` asks the server for an
+ * authorization URL — the server mints the `state` and the PKCE challenge,
+ * keeps the client secret, and is the only party that ever sees the code —
+ * and the browser navigates to it. What comes back lands on
+ * `/auth/callback/google`, which is the API's route, not the SPA's.
+ *
+ * The one thing this file owns is where the person ends up afterwards, in
+ * all three outcomes: signed in, cancelled, or failed.
+ */
+
+import { authClient } from "../client.ts";
+
+/** Better Auth appends `?error=…` when it sends the browser here. */
+const OAUTH_ERROR_PATH = "/login";
+
+interface SocialSignInTargets {
+  /** Where to land once the session cookie is set. */
+  callbackURL: string;
+}
+
+/**
+ * Starts the Google flow. Resolves only if the redirect never happened —
+ * on success the browser has already left this document.
+ */
+export async function signInWithGoogle({
+  callbackURL,
+}: SocialSignInTargets): Promise<void> {
+  const { error } = await authClient.signIn.social({
+    provider: "google",
+    callbackURL,
+    // A cancelled or rejected consent screen comes back to the login page
+    // with an error code rather than to a blank Better Auth error route.
+    errorCallbackURL: OAUTH_ERROR_PATH,
+    // No `newUserCallbackURL`: a first sign-in and a returning one land in
+    // the same place. Onboarding is decided by what the account holds, not
+    // by which URL the browser arrived on.
+  });
+
+  if (error) {
+    // The provider was never reached — the request to our own server
+    // failed. Surfaced the same way a returned `?error=` is.
+    throw new Error(`social sign-in failed (${error.status ?? "network"})`);
+  }
+}

--- a/apps/web/src/auth/sign-in/social.ts
+++ b/apps/web/src/auth/sign-in/social.ts
@@ -1,25 +1,22 @@
 /**
- * Social sign-in: hand the browser to the provider and let Better Auth own
- * the rest.
- *
- * Nothing here implements OAuth. `signIn.social` asks the server for an
- * authorization URL — the server mints the `state` and the PKCE challenge,
- * keeps the client secret, and is the only party that ever sees the code —
- * and the browser navigates to it. What comes back lands on
- * `/auth/callback/google`, which is the API's route, not the SPA's.
- *
- * The one thing this file owns is where the person ends up afterwards, in
- * all three outcomes: signed in, cancelled, or failed.
+ * Social sign-in. OAuth itself (state, PKCE, secrets) is Better Auth's,
+ * server-side; the return lands on `/auth/callback/google` — the API's
+ * route, not the SPA's. This file only decides where the person ends up.
  */
 
 import { authClient } from "../client.ts";
 
-/** Better Auth appends `?error=…` when it sends the browser here. */
-const OAUTH_ERROR_PATH = "/login";
-
 interface SocialSignInTargets {
   /** Where to land once the session cookie is set. */
   callbackURL: string;
+  /** Interrupted destination, kept through the failure leg too. */
+  redirect?: string | undefined;
+}
+
+// Better Auth appends ?error= (or &error= when a query exists); the
+// login route re-validates `redirect` as an internal path on arrival.
+function errorCallbackOf(redirect: string | undefined): string {
+  return redirect ? `/login?redirect=${encodeURIComponent(redirect)}` : "/login";
 }
 
 /**
@@ -28,21 +25,15 @@ interface SocialSignInTargets {
  */
 export async function signInWithGoogle({
   callbackURL,
+  redirect,
 }: SocialSignInTargets): Promise<void> {
   const { error } = await authClient.signIn.social({
     provider: "google",
     callbackURL,
-    // A cancelled or rejected consent screen comes back to the login page
-    // with an error code rather than to a blank Better Auth error route.
-    errorCallbackURL: OAUTH_ERROR_PATH,
-    // No `newUserCallbackURL`: a first sign-in and a returning one land in
-    // the same place. Onboarding is decided by what the account holds, not
-    // by which URL the browser arrived on.
+    errorCallbackURL: errorCallbackOf(redirect),
   });
 
   if (error) {
-    // The provider was never reached — the request to our own server
-    // failed. Surfaced the same way a returned `?error=` is.
     throw new Error(`social sign-in failed (${error.status ?? "network"})`);
   }
 }

--- a/apps/web/src/auth/sign-in/social.ts
+++ b/apps/web/src/auth/sign-in/social.ts
@@ -1,15 +1,18 @@
 /**
- * Social sign-in. OAuth itself (state, PKCE, secrets) is Better Auth's,
- * server-side; the return lands on `/api/auth/callback/google` — the
- * API's route, not the SPA's. This file only decides where the person
- * ends up.
+ * Starts social sign-in through Better Auth.
+ *
+ * Better Auth owns the OAuth flow and the provider callback
+ * (`/api/auth/callback/google` — Google's return leg, not this file's
+ * concern). This module only defines where the user lands after that:
+ * `successURL` on success, `errorCallbackOf(redirect)` on failure.
  */
 
 import { authClient } from "../client.ts";
 
 interface SocialSignInTargets {
-  /** Where to land once the session cookie is set. */
-  callbackURL: string;
+  /** Where to land once the session cookie is set — not the OAuth
+   * provider callback, which Better Auth builds itself. */
+  successURL: string;
   /** Interrupted destination, kept through the failure leg too. */
   redirect?: string | undefined;
 }
@@ -25,12 +28,12 @@ function errorCallbackOf(redirect: string | undefined): string {
  * on success the browser has already left this document.
  */
 export async function signInWithGoogle({
-  callbackURL,
+  successURL,
   redirect,
 }: SocialSignInTargets): Promise<void> {
   const { error } = await authClient.signIn.social({
     provider: "google",
-    callbackURL,
+    callbackURL: successURL,
     errorCallbackURL: errorCallbackOf(redirect),
   });
 

--- a/apps/web/src/auth/sign-in/social.ts
+++ b/apps/web/src/auth/sign-in/social.ts
@@ -1,7 +1,8 @@
 /**
  * Social sign-in. OAuth itself (state, PKCE, secrets) is Better Auth's,
- * server-side; the return lands on `/auth/callback/google` — the API's
- * route, not the SPA's. This file only decides where the person ends up.
+ * server-side; the return lands on `/api/auth/callback/google` — the
+ * API's route, not the SPA's. This file only decides where the person
+ * ends up.
  */
 
 import { authClient } from "../client.ts";

--- a/apps/web/src/auth/sign-in/use-sign-in.ts
+++ b/apps/web/src/auth/sign-in/use-sign-in.ts
@@ -1,7 +1,11 @@
-/** Session cache is set from the sign-in response, not refetched — avoids a window where the guard still reads "signed out". */
+/**
+ * Identity transition: `removeQueries` (not invalidate — the previous
+ * user's data must not stay visible), then seed the session from the
+ * sign-in response, so no follow-up fetch can fail a successful sign-in.
+ */
 
 import { signIn, type Credentials } from "./sign-in.ts";
-import { fetchSession, sessionQueryKey } from "../session.ts";
+import { sessionQueryKey } from "../session.ts";
 import { useMutation, useQueryClient } from "../../shared/libs/query/index.ts";
 
 export function useSignIn() {
@@ -9,11 +13,9 @@ export function useSignIn() {
 
   return useMutation({
     mutationFn: (credentials: Credentials) => signIn(credentials),
-    onSuccess: async () => {
-      queryClient.setQueryData(sessionQueryKey, await fetchSession());
-      // Everything cached under the previous visitor is now somebody
-      // else's data. Dropping it is cheaper than auditing every key.
-      await queryClient.invalidateQueries();
+    onSuccess: (user) => {
+      queryClient.removeQueries();
+      queryClient.setQueryData(sessionQueryKey, user);
     },
   });
 }

--- a/apps/web/src/auth/user-avatar.tsx
+++ b/apps/web/src/auth/user-avatar.tsx
@@ -5,7 +5,6 @@ import { Avatar, AvatarFallback, AvatarImage } from "@velachess/ui/components/av
 
 import type { SessionUser } from "./client.ts";
 
-/** First and last initial; falls back to the email's first letter. */
 function initialsOf(user: Pick<SessionUser, "name" | "email">): string {
   const words = user.name.trim().split(/\s+/).filter(Boolean);
   const letters = [words[0], words.length > 1 ? words.at(-1) : undefined]
@@ -27,7 +26,9 @@ export function UserAvatar({
 }) {
   return (
     <Avatar size={size} {...(className ? { className } : {})}>
-      {user.image ? <AvatarImage src={user.image} alt="" /> : null}
+      {user.image ? (
+        <AvatarImage src={user.image} alt="" referrerPolicy="no-referrer" />
+      ) : null}
       <AvatarFallback>{initialsOf(user)}</AvatarFallback>
     </Avatar>
   );

--- a/apps/web/src/auth/user-avatar.tsx
+++ b/apps/web/src/auth/user-avatar.tsx
@@ -1,0 +1,50 @@
+/**
+ * The signed-in person, as a picture.
+ *
+ * One component, because the shell's menu and the account screen must not
+ * disagree about what someone looks like — and because the fallback is the
+ * interesting part: an account created with email and password has no
+ * `image` at all, so initials are the normal case, not the error case.
+ */
+
+import { Avatar, AvatarFallback, AvatarImage } from "@velachess/ui/components/avatar";
+
+import type { SessionUser } from "./client.ts";
+
+/**
+ * At most two letters, from the first and last word of the name.
+ *
+ * Falls back to the email's first character, then to nothing — a name is
+ * required by Better Auth, but a name of `" "` is not, and an avatar that
+ * throws is worse than one that is briefly blank.
+ */
+function initialsOf(user: Pick<SessionUser, "name" | "email">): string {
+  const words = user.name.trim().split(/\s+/).filter(Boolean);
+  const letters = [words[0], words.length > 1 ? words.at(-1) : undefined]
+    .filter((word): word is string => Boolean(word))
+    .map((word) => [...word][0]!)
+    .join("");
+
+  return (letters || [...user.email][0] || "").toUpperCase();
+}
+
+export function UserAvatar({
+  user,
+  size = "default",
+  className,
+}: {
+  user: Pick<SessionUser, "name" | "email" | "image">;
+  size?: "default" | "sm" | "lg";
+  className?: string;
+}) {
+  return (
+    <Avatar size={size} {...(className ? { className } : {})}>
+      {/* The provider's URL, straight from the session. It is remote and
+          may 404 — Avatar's own fallback covers that without this
+          component having to know. Decorative: every place this appears,
+          the name is written next to it. */}
+      {user.image ? <AvatarImage src={user.image} alt="" /> : null}
+      <AvatarFallback>{initialsOf(user)}</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/apps/web/src/auth/user-avatar.tsx
+++ b/apps/web/src/auth/user-avatar.tsx
@@ -1,23 +1,11 @@
-/**
- * The signed-in person, as a picture.
- *
- * One component, because the shell's menu and the account screen must not
- * disagree about what someone looks like — and because the fallback is the
- * interesting part: an account created with email and password has no
- * `image` at all, so initials are the normal case, not the error case.
- */
+/** The signed-in person, as a picture. Initials are the normal case —
+ * a password account has no `image`. */
 
 import { Avatar, AvatarFallback, AvatarImage } from "@velachess/ui/components/avatar";
 
 import type { SessionUser } from "./client.ts";
 
-/**
- * At most two letters, from the first and last word of the name.
- *
- * Falls back to the email's first character, then to nothing — a name is
- * required by Better Auth, but a name of `" "` is not, and an avatar that
- * throws is worse than one that is briefly blank.
- */
+/** First and last initial; falls back to the email's first letter. */
 function initialsOf(user: Pick<SessionUser, "name" | "email">): string {
   const words = user.name.trim().split(/\s+/).filter(Boolean);
   const letters = [words[0], words.length > 1 ? words.at(-1) : undefined]
@@ -39,10 +27,6 @@ export function UserAvatar({
 }) {
   return (
     <Avatar size={size} {...(className ? { className } : {})}>
-      {/* The provider's URL, straight from the session. It is remote and
-          may 404 — Avatar's own fallback covers that without this
-          component having to know. Decorative: every place this appears,
-          the name is written next to it. */}
       {user.image ? <AvatarImage src={user.image} alt="" /> : null}
       <AvatarFallback>{initialsOf(user)}</AvatarFallback>
     </Avatar>

--- a/apps/web/src/games/__tests__/rate-limit.test.tsx
+++ b/apps/web/src/games/__tests__/rate-limit.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { addGames } from "../../test/archive.ts";
+import { deviceHasImported } from "../../test/device.ts";
+import { aGame } from "../../test/games.ts";
+import { renderApp } from "../../test/render.tsx";
+import { server } from "../../test/server.ts";
+
+/**
+ * What a person sees when the server says "not now" — the one refusal
+ * that must not read as a failure.
+ *
+ * A 429 asks for the opposite reaction from every other error: wait,
+ * instead of retry. So each screen that can hit one has to say when to
+ * come back (the body's `retryAfterSeconds` — the client cannot read a
+ * rejection's headers) and must not use the vocabulary of breakage.
+ */
+
+/** The refusal as the rate-limit middleware writes it. */
+const rateLimited = (retryAfterSeconds: number) =>
+  HttpResponse.json(
+    { error: "too many requests", retryAfterSeconds },
+    { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } },
+  );
+
+describe("a throttled analysis", () => {
+  beforeEach(() => deviceHasImported());
+
+  it("says it is a wait, with the wait, not a failure", async () => {
+    const game = aGame();
+    addGames(game);
+    server.use(http.post("/api/games/:id/analyze", () => rateLimited(42)));
+
+    await renderApp({ path: `/games/${game.id}` });
+
+    expect(await screen.findByText("Too many analyses at once.")).toBeInTheDocument();
+    expect(screen.getByText("Try again in 42 seconds.")).toBeInTheDocument();
+    // The failure vocabulary stays out of it — "couldn't load" invites
+    // an immediate retry, which is what the refusal asked not to get.
+    expect(screen.queryByText("Couldn't load analysis.")).not.toBeInTheDocument();
+  });
+
+  it("keeps the plain failure message for a genuine failure", async () => {
+    const game = aGame();
+    addGames(game);
+    server.use(
+      http.post("/api/games/:id/analyze", () =>
+        HttpResponse.json({ error: "internal error" }, { status: 500 }),
+      ),
+    );
+
+    await renderApp({ path: `/games/${game.id}` });
+
+    expect(await screen.findByText("Couldn't load analysis.")).toBeInTheDocument();
+    expect(screen.queryByText(/Try again in \d+ seconds/)).not.toBeInTheDocument();
+  });
+});
+
+describe("a throttled sync", () => {
+  beforeEach(() => {
+    deviceHasImported();
+    addGames(aGame({ blackName: "already-here" }));
+  });
+
+  it("lands in the same calm toast as the domain cooldown", async () => {
+    // The API rate limit and the sync cooldown are different mechanisms
+    // on the server and the same fact to the person: come back shortly.
+    server.use(http.post("/api/accounts/:id/sync", () => rateLimited(37)));
+
+    const { user } = await renderApp();
+    await screen.findByText("already-here");
+
+    await user.click(screen.getByRole("button", { name: "Sync games" }));
+
+    expect(await screen.findByText("Synced a moment ago")).toBeInTheDocument();
+    expect(screen.getByText("Try again in 37 seconds.")).toBeInTheDocument();
+    expect(screen.queryByText("Couldn't reach that account")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/games/import/__tests__/sync-games-button.test.tsx
+++ b/apps/web/src/games/import/__tests__/sync-games-button.test.tsx
@@ -54,6 +54,8 @@ describe("sync games button", () => {
     await user.click(screen.getByRole("button", { name: "Sync games" }));
 
     expect(await screen.findByText("Synced a moment ago")).toBeInTheDocument();
+    // With the actual wait — "a moment" invites an immediate retry.
+    expect(screen.getByText("Try again in 45 seconds.")).toBeInTheDocument();
   });
 
   it("syncs the accounts the server knows, never a stale remembered id", async () => {

--- a/apps/web/src/games/import/queries.ts
+++ b/apps/web/src/games/import/queries.ts
@@ -1,15 +1,10 @@
-import {
-  api,
-  DetailedError,
-  parseResponse,
-  type InferResponseType,
-} from "../../shared/api/client.ts";
+import { api, parseResponse, type InferResponseType } from "../../shared/api/client.ts";
+import { isRateLimitedError } from "../../shared/api/errors.ts";
 import {
   queryOptions,
   useMutation,
   useQueryClient,
 } from "../../shared/libs/query/index.ts";
-import { z } from "../../shared/libs/zod.ts";
 import { useMyAccounts, type RememberedAccount } from "./my-accounts.ts";
 import { INPUT_KINDS, type SourceId } from "./sources.ts";
 
@@ -74,8 +69,6 @@ export type SyncOutcome =
   | { status: "refreshed"; saved: number }
   | { status: "too-soon"; retryAfterSeconds: number };
 
-const tooSoonSchema = z.object({ retryAfterSeconds: z.number() });
-
 /** Pulls fresh games for every account the server tracks. Server ids,
  * never the device's remembered ones: a browser can hold an id from a
  * database that no longer exists, and syncing it 404s forever. */
@@ -102,14 +95,15 @@ export function useSyncGames(handlers: {
           );
           saved += result.saved;
         } catch (error) {
-          if (error instanceof DetailedError && error.statusCode === 429) {
-            const tooSoon = tooSoonSchema.safeParse(error.detail?.data);
-            if (tooSoon.success) {
-              return {
-                status: "too-soon",
-                retryAfterSeconds: tooSoon.data.retryAfterSeconds,
-              };
-            }
+          // Either throttle — the domain cooldown or the API rate limit —
+          // arrives as the same class with the same wait, so "come back in
+          // a moment" is one outcome, not two. A 429 that somehow carried
+          // no wait falls back to the cooldown's own window.
+          if (isRateLimitedError(error)) {
+            return {
+              status: "too-soon",
+              retryAfterSeconds: error.retryAfterSeconds ?? 60,
+            };
           }
           throw error;
         }

--- a/apps/web/src/games/import/sync-games-button.tsx
+++ b/apps/web/src/games/import/sync-games-button.tsx
@@ -28,7 +28,7 @@ const SYNC_COPY = {
 // Parameterised, so it lives outside the const table the way the insights
 // coverage line does. The wait is the one fact that makes this toast
 // actionable — "a moment" invites an immediate retry; a number does not.
-const retryIn = msg`Try again in {seconds} seconds.`;
+const retryIn = msg`{seconds, plural, one {Try again in # second.} other {Try again in # seconds.}}`;
 
 export function SyncGamesButton() {
   const { i18n } = useLingui();
@@ -42,7 +42,9 @@ export function SyncGamesButton() {
           title: i18n._(SYNC_COPY.tooSoon),
           description: i18n._({
             ...retryIn,
-            values: { seconds: i18n.number(outcome.retryAfterSeconds) },
+            // Raw, not i18n.number()'d: the plural rule itself picks the
+            // category from the number, and `#` formats it.
+            values: { seconds: outcome.retryAfterSeconds },
           }),
         });
         return;

--- a/apps/web/src/games/import/sync-games-button.tsx
+++ b/apps/web/src/games/import/sync-games-button.tsx
@@ -25,6 +25,11 @@ const SYNC_COPY = {
   retry: msg`Try again in a moment.`,
 } as const;
 
+// Parameterised, so it lives outside the const table the way the insights
+// coverage line does. The wait is the one fact that makes this toast
+// actionable — "a moment" invites an immediate retry; a number does not.
+const retryIn = msg`Try again in {seconds} seconds.`;
+
 export function SyncGamesButton() {
   const { i18n } = useLingui();
   const accounts = useQuery(trackedAccountsQuery).data ?? [];
@@ -35,7 +40,10 @@ export function SyncGamesButton() {
         toast.add({
           type: "info",
           title: i18n._(SYNC_COPY.tooSoon),
-          description: i18n._(SYNC_COPY.retry),
+          description: i18n._({
+            ...retryIn,
+            values: { seconds: i18n.number(outcome.retryAfterSeconds) },
+          }),
         });
         return;
       }

--- a/apps/web/src/games/open-game/analysis-panel.tsx
+++ b/apps/web/src/games/open-game/analysis-panel.tsx
@@ -36,6 +36,8 @@ export interface AnalysisPanelProps {
   onShowBest: (san: string) => void;
   isAnalyzing: boolean;
   hasFailed: boolean;
+  /** The wait, when the failure is the rate limit and not a defect. */
+  retryAfterSeconds: number | null;
 }
 
 /**
@@ -63,6 +65,7 @@ export function AnalysisPanel({
   onShowBest,
   isAnalyzing,
   hasFailed,
+  retryAfterSeconds,
 }: AnalysisPanelProps) {
   const { i18n } = useLingui();
   const breakdown = summarize(graded);
@@ -78,6 +81,7 @@ export function AnalysisPanel({
         totalPlies={replay.totalPlies}
         isAnalyzing={isAnalyzing}
         hasFailed={hasFailed}
+        retryAfterSeconds={retryAfterSeconds}
       />
 
       {/*

--- a/apps/web/src/games/open-game/game-analysis.tsx
+++ b/apps/web/src/games/open-game/game-analysis.tsx
@@ -74,6 +74,7 @@ function GameAnalysisContent({ gameId }: { gameId: string }) {
     graded,
     isAnalyzing,
     analysisFailed,
+    analysisRetryAfterSeconds,
   } = useAnalysis(gameId);
 
   // Ignored while a form field has focus (react-hotkeys-hook default) —
@@ -157,6 +158,7 @@ function GameAnalysisContent({ gameId }: { gameId: string }) {
         graded={graded}
         isAnalyzing={isAnalyzing}
         hasFailed={analysisFailed}
+        retryAfterSeconds={analysisRetryAfterSeconds}
       />
     </BoardScreen>
   );

--- a/apps/web/src/games/request-analysis/analysis-status.tsx
+++ b/apps/web/src/games/request-analysis/analysis-status.tsx
@@ -16,7 +16,7 @@ const STATUS_COPY = {
 const analyzingLabel = (graded: number, total: number) =>
   msg`Analyzing move ${graded} of ${total}…`;
 
-const rateLimitedRetry = msg`Try again in {seconds} seconds.`;
+const rateLimitedRetry = msg`{seconds, plural, one {Try again in # second.} other {Try again in # seconds.}}`;
 
 export interface AnalysisStatusProps {
   graded: number;
@@ -51,7 +51,9 @@ export function AnalysisStatus({
             <AlertDescription>
               {i18n._({
                 ...rateLimitedRetry,
-                values: { seconds: i18n.number(retryAfterSeconds) },
+                // Raw, not i18n.number()'d: the plural rule itself picks
+                // the category from the number, and `#` formats it.
+                values: { seconds: retryAfterSeconds },
               })}
             </AlertDescription>
           </Alert>

--- a/apps/web/src/games/request-analysis/analysis-status.tsx
+++ b/apps/web/src/games/request-analysis/analysis-status.tsx
@@ -1,7 +1,7 @@
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 
-import { Alert, AlertTitle } from "@velachess/ui/components/alert";
+import { Alert, AlertDescription, AlertTitle } from "@velachess/ui/components/alert";
 import { Progress } from "@velachess/ui/components/progress";
 import { Spinner } from "@velachess/ui/components/spinner";
 
@@ -10,16 +10,21 @@ import { progressPercent } from "../analysis-read.ts";
 const STATUS_COPY = {
   preparing: msg`Preparing analysis…`,
   loadError: msg`Couldn't load analysis.`,
+  rateLimited: msg`Too many analyses at once.`,
 } as const;
 
 const analyzingLabel = (graded: number, total: number) =>
   msg`Analyzing move ${graded} of ${total}…`;
+
+const rateLimitedRetry = msg`Try again in {seconds} seconds.`;
 
 export interface AnalysisStatusProps {
   graded: number;
   totalPlies: number;
   isAnalyzing: boolean;
   hasFailed: boolean;
+  /** Set when the failure is the rate limit — a wait, not a defect. */
+  retryAfterSeconds?: number | null;
 }
 
 export function AnalysisStatus({
@@ -27,12 +32,33 @@ export function AnalysisStatus({
   totalPlies,
   isAnalyzing,
   hasFailed,
+  retryAfterSeconds = null,
 }: AnalysisStatusProps) {
   const { i18n } = useLingui();
 
   if (!isAnalyzing && !hasFailed) return null;
 
   if (hasFailed) {
+    // A throttled run is not a broken one, and telling someone their
+    // analysis "couldn't load" when it was refused on purpose teaches
+    // exactly the wrong reaction — mash the button again. `info`, with
+    // the wait, because there is nothing to fix and a time to come back.
+    if (retryAfterSeconds !== null) {
+      return (
+        <div className="shrink-0 border-b p-3">
+          <Alert>
+            <AlertTitle>{i18n._(STATUS_COPY.rateLimited)}</AlertTitle>
+            <AlertDescription>
+              {i18n._({
+                ...rateLimitedRetry,
+                values: { seconds: i18n.number(retryAfterSeconds) },
+              })}
+            </AlertDescription>
+          </Alert>
+        </div>
+      );
+    }
+
     return (
       <div className="shrink-0 border-b p-3">
         <Alert variant="destructive">

--- a/apps/web/src/games/watch-analysis/use-analysis.ts
+++ b/apps/web/src/games/watch-analysis/use-analysis.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { isRateLimitedError } from "../../shared/api/errors.ts";
 import { useQuery, useQueryClient } from "../../shared/libs/query/index.ts";
 import {
   analysisKey,
@@ -26,6 +27,9 @@ export interface Analysis {
   /** The run is open. `isFetching`, never `isPending`: `streamedQuery` writes each chunk via `setQueryData`, so success fires after the first graded move. */
   isAnalyzing: boolean;
   analysisFailed: boolean;
+  /** Set when the failure was the rate limit refusing the run — the one
+   * failure that is not a failure, just a wait. Null for every other. */
+  analysisRetryAfterSeconds: number | null;
 }
 
 export function useAnalysis(gameId: string): Analysis {
@@ -63,5 +67,8 @@ export function useAnalysis(gameId: string): Analysis {
     drills: drills.data ?? undefined,
     isAnalyzing: analysis.isFetching,
     analysisFailed: analysis.isError,
+    analysisRetryAfterSeconds: isRateLimitedError(analysis.error)
+      ? (analysis.error.retryAfterSeconds ?? 60)
+      : null,
   };
 }

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -257,10 +257,6 @@ msgstr "Connected — you can sign in with Google."
 msgid "Continue"
 msgstr "Continue"
 
-#: src/auth/sign-in/sign-in-screen.tsx:44
-msgid "Continue with Google"
-msgstr "Continue with Google"
-
 #: src/repertoire/repertoire-practice.tsx:62
 msgid "Correct."
 msgstr "Correct."
@@ -310,7 +306,7 @@ msgstr "Couldn't load your sign-in methods."
 msgid "Couldn't reach that account"
 msgstr "Couldn't reach that account"
 
-#: src/auth/sign-in/sign-in-screen.tsx:40
+#: src/auth/sign-in/sign-in-screen.tsx:45
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr "Couldn't reach the server. Try again in a moment."
 
@@ -361,7 +357,7 @@ msgstr "Drills from the mistakes that cost you"
 msgid "Due now"
 msgstr "Due now"
 
-#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/auth/sign-in/sign-in-screen.tsx:40
 #: src/settings/account/account-screen.tsx:40
 msgid "Email"
 msgstr "Email"
@@ -382,11 +378,15 @@ msgstr "endgame"
 msgid "Enter a name."
 msgstr "Enter a name."
 
-#: src/auth/sign-in/sign-in-screen.tsx:41
+#: src/auth/sign-in/sign-in-screen.tsx:39
+msgid "Enter your email below to login to your account"
+msgstr "Enter your email below to login to your account"
+
+#: src/auth/sign-in/sign-in-screen.tsx:46
 msgid "Enter your email."
 msgstr "Enter your email."
 
-#: src/auth/sign-in/sign-in-screen.tsx:43
+#: src/auth/sign-in/sign-in-screen.tsx:48
 msgid "Enter your password."
 msgstr "Enter your password."
 
@@ -471,11 +471,11 @@ msgstr "Good"
 msgid "Google"
 msgstr "Google"
 
-#: src/auth/sign-in/sign-in-screen.tsx:47
+#: src/auth/sign-in/sign-in-screen.tsx:52
 msgid "Google sign-in didn't complete. Try again."
 msgstr "Google sign-in didn't complete. Try again."
 
-#: src/auth/sign-in/sign-in-screen.tsx:46
+#: src/auth/sign-in/sign-in-screen.tsx:51
 msgid "Google sign-in was cancelled."
 msgstr "Google sign-in was cancelled."
 
@@ -516,7 +516,7 @@ msgstr "Inaccuracy"
 msgid "Insights"
 msgstr "Insights"
 
-#: src/auth/sign-in/sign-in-screen.tsx:39
+#: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Invalid email or password."
 msgstr "Invalid email or password."
 
@@ -584,6 +584,22 @@ msgstr "Loading the game…"
 #: src/repertoire/repertoire-practice.tsx:53
 msgid "Loading…"
 msgstr "Loading…"
+
+#: src/auth/sign-in/sign-in-screen.tsx:43
+msgid "Logging in…"
+msgstr "Logging in…"
+
+#: src/auth/sign-in/sign-in-screen.tsx:42
+msgid "Login"
+msgstr "Login"
+
+#: src/auth/sign-in/sign-in-screen.tsx:49
+msgid "Login with Google"
+msgstr "Login with Google"
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
+msgid "Login with your Google account"
+msgstr "Login with your Google account"
 
 #: src/insights/finding-views.tsx:99
 msgid "Look at these games"
@@ -755,11 +771,11 @@ msgstr "Opponent moves your repertoire has no answer to, most frequent first. Co
 msgid "Opponent plays:"
 msgstr "Opponent plays:"
 
-#: src/auth/sign-in/sign-in-screen.tsx:45
-msgid "or"
-msgstr "or"
+#: src/auth/sign-in/sign-in-screen.tsx:50
+msgid "Or continue with"
+msgstr "Or continue with"
 
-#: src/auth/sign-in/sign-in-screen.tsx:36
+#: src/auth/sign-in/sign-in-screen.tsx:41
 msgid "Password"
 msgstr "Password"
 
@@ -941,14 +957,6 @@ msgstr "Settings"
 msgid "Show the engine's move on the board"
 msgstr "Show the engine's move on the board"
 
-#: src/auth/sign-in/sign-in-screen.tsx:37
-msgid "Sign in"
-msgstr "Sign in"
-
-#: src/auth/sign-in/sign-in-screen.tsx:34
-msgid "Sign in to your VelaChess instance."
-msgstr "Sign in to your VelaChess instance."
-
 #: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr "Sign out"
@@ -956,10 +964,6 @@ msgstr "Sign out"
 #: src/settings/account/account-screen.tsx:46
 msgid "Sign-in methods"
 msgstr "Sign-in methods"
-
-#: src/auth/sign-in/sign-in-screen.tsx:38
-msgid "Signing in…"
-msgstr "Signing in…"
 
 #: src/app-shell/user-menu.tsx:23
 msgid "Signing out…"
@@ -1011,7 +1015,7 @@ msgstr "Synced a moment ago"
 msgid "Syncing…"
 msgstr "Syncing…"
 
-#: src/auth/sign-in/sign-in-screen.tsx:42
+#: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "That doesn't look like an email address."
 msgstr "That doesn't look like an email address."
 
@@ -1152,7 +1156,7 @@ msgstr "waiting for you today"
 msgid "Ways you can get into this account."
 msgstr "Ways you can get into this account."
 
-#: src/auth/sign-in/sign-in-screen.tsx:33
+#: src/auth/sign-in/sign-in-screen.tsx:37
 msgid "Welcome back"
 msgstr "Welcome back"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -134,7 +134,7 @@ msgstr "Already up to date"
 msgid "An unexpected error interrupted this screen."
 msgstr "An unexpected error interrupted this screen."
 
-#: src/games/request-analysis/analysis-status.tsx:16
+#: src/games/request-analysis/analysis-status.tsx:17
 msgid "Analyzing move {graded} of {total}…"
 msgstr "Analyzing move {graded} of {total}…"
 
@@ -1079,6 +1079,10 @@ msgstr "Today"
 msgid "too few moves to judge"
 msgstr "too few moves to judge"
 
+#: src/games/request-analysis/analysis-status.tsx:13
+msgid "Too many analyses at once."
+msgstr "Too many analyses at once."
+
 #: src/insights/finding-views.tsx:98
 msgid "Train the moves you missed"
 msgstr "Train the moves you missed"
@@ -1096,6 +1100,11 @@ msgstr "Training"
 #: src/shared/ui/route-error.tsx:16
 msgid "Try again"
 msgstr "Try again"
+
+#: src/games/import/sync-games-button.tsx:31
+#: src/games/request-analysis/analysis-status.tsx:19
+msgid "Try again in {seconds} seconds."
+msgstr "Try again in {seconds} seconds."
 
 #: src/games/import/sync-games-button.tsx:25
 msgid "Try again in a moment."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -107,6 +107,11 @@ msgstr "{rate} adherence over {games} judged games · prep runs {depth} moves de
 msgid "{rate} of {count, plural, one {# game} other {# games}}"
 msgstr "{rate} of {count, plural, one {# game} other {# games}}"
 
+#: src/games/import/sync-games-button.tsx:31
+#: src/games/request-analysis/analysis-status.tsx:19
+msgid "{seconds, plural, one {Try again in # second.} other {Try again in # seconds.}}"
+msgstr "{seconds, plural, one {Try again in # second.} other {Try again in # seconds.}}"
+
 #: src/games/open-game/game-analysis.tsx:30
 msgid "{white} vs {black}"
 msgstr "{white} vs {black}"
@@ -129,6 +134,10 @@ msgstr "Across {games, plural, one {# analysed game} other {# analysed games}}."
 #: src/games/import/sync-games-button.tsx:20
 msgid "Already up to date"
 msgstr "Already up to date"
+
+#: src/auth/sign-in/sign-in-screen.tsx:52
+msgid "An account already exists with that email. Sign in with your password instead."
+msgstr "An account already exists with that email. Sign in with your password instead."
 
 #: src/shared/ui/route-error.tsx:15
 msgid "An unexpected error interrupted this screen."
@@ -1108,11 +1117,6 @@ msgstr "Training"
 #: src/shared/ui/route-error.tsx:16
 msgid "Try again"
 msgstr "Try again"
-
-#: src/games/import/sync-games-button.tsx:31
-#: src/games/request-analysis/analysis-status.tsx:19
-msgid "Try again in {seconds} seconds."
-msgstr "Try again in {seconds} seconds."
 
 #: src/games/import/sync-games-button.tsx:25
 msgid "Try again in a moment."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -257,6 +257,18 @@ msgstr "Connected — you can sign in with Google."
 msgid "Continue"
 msgstr "Continue"
 
+#: src/auth/sign-in/sign-in-screen.tsx:36
+msgid "Continue to VelaChess"
+msgstr "Continue to VelaChess"
+
+#: src/auth/sign-in/sign-in-screen.tsx:48
+msgid "Continue with Google"
+msgstr "Continue with Google"
+
+#: src/auth/sign-in/sign-in-screen.tsx:37
+msgid "Continue with Google or sign in with your account credentials."
+msgstr "Continue with Google or sign in with your account credentials."
+
 #: src/repertoire/repertoire-practice.tsx:62
 msgid "Correct."
 msgstr "Correct."
@@ -306,7 +318,7 @@ msgstr "Couldn't load your sign-in methods."
 msgid "Couldn't reach that account"
 msgstr "Couldn't reach that account"
 
-#: src/auth/sign-in/sign-in-screen.tsx:45
+#: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr "Couldn't reach the server. Try again in a moment."
 
@@ -357,7 +369,7 @@ msgstr "Drills from the mistakes that cost you"
 msgid "Due now"
 msgstr "Due now"
 
-#: src/auth/sign-in/sign-in-screen.tsx:40
+#: src/auth/sign-in/sign-in-screen.tsx:39
 #: src/settings/account/account-screen.tsx:40
 msgid "Email"
 msgstr "Email"
@@ -378,15 +390,11 @@ msgstr "endgame"
 msgid "Enter a name."
 msgstr "Enter a name."
 
-#: src/auth/sign-in/sign-in-screen.tsx:39
-msgid "Enter your email below to login to your account"
-msgstr "Enter your email below to login to your account"
-
-#: src/auth/sign-in/sign-in-screen.tsx:46
+#: src/auth/sign-in/sign-in-screen.tsx:45
 msgid "Enter your email."
 msgstr "Enter your email."
 
-#: src/auth/sign-in/sign-in-screen.tsx:48
+#: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "Enter your password."
 msgstr "Enter your password."
 
@@ -471,11 +479,11 @@ msgstr "Good"
 msgid "Google"
 msgstr "Google"
 
-#: src/auth/sign-in/sign-in-screen.tsx:52
+#: src/auth/sign-in/sign-in-screen.tsx:51
 msgid "Google sign-in didn't complete. Try again."
 msgstr "Google sign-in didn't complete. Try again."
 
-#: src/auth/sign-in/sign-in-screen.tsx:51
+#: src/auth/sign-in/sign-in-screen.tsx:50
 msgid "Google sign-in was cancelled."
 msgstr "Google sign-in was cancelled."
 
@@ -516,7 +524,7 @@ msgstr "Inaccuracy"
 msgid "Insights"
 msgstr "Insights"
 
-#: src/auth/sign-in/sign-in-screen.tsx:44
+#: src/auth/sign-in/sign-in-screen.tsx:43
 msgid "Invalid email or password."
 msgstr "Invalid email or password."
 
@@ -584,22 +592,6 @@ msgstr "Loading the game…"
 #: src/repertoire/repertoire-practice.tsx:53
 msgid "Loading…"
 msgstr "Loading…"
-
-#: src/auth/sign-in/sign-in-screen.tsx:43
-msgid "Logging in…"
-msgstr "Logging in…"
-
-#: src/auth/sign-in/sign-in-screen.tsx:42
-msgid "Login"
-msgstr "Login"
-
-#: src/auth/sign-in/sign-in-screen.tsx:49
-msgid "Login with Google"
-msgstr "Login with Google"
-
-#: src/auth/sign-in/sign-in-screen.tsx:38
-msgid "Login with your Google account"
-msgstr "Login with your Google account"
 
 #: src/insights/finding-views.tsx:99
 msgid "Look at these games"
@@ -771,11 +763,11 @@ msgstr "Opponent moves your repertoire has no answer to, most frequent first. Co
 msgid "Opponent plays:"
 msgstr "Opponent plays:"
 
-#: src/auth/sign-in/sign-in-screen.tsx:50
+#: src/auth/sign-in/sign-in-screen.tsx:49
 msgid "Or continue with"
 msgstr "Or continue with"
 
-#: src/auth/sign-in/sign-in-screen.tsx:41
+#: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Password"
 msgstr "Password"
 
@@ -957,6 +949,14 @@ msgstr "Settings"
 msgid "Show the engine's move on the board"
 msgstr "Show the engine's move on the board"
 
+#: src/auth/sign-in/sign-in-screen.tsx:41
+msgid "Sign in"
+msgstr "Sign in"
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
+msgid "Sign in with your account credentials."
+msgstr "Sign in with your account credentials."
+
 #: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr "Sign out"
@@ -964,6 +964,10 @@ msgstr "Sign out"
 #: src/settings/account/account-screen.tsx:46
 msgid "Sign-in methods"
 msgstr "Sign-in methods"
+
+#: src/auth/sign-in/sign-in-screen.tsx:42
+msgid "Signing in…"
+msgstr "Signing in…"
 
 #: src/app-shell/user-menu.tsx:23
 msgid "Signing out…"
@@ -1015,7 +1019,7 @@ msgstr "Synced a moment ago"
 msgid "Syncing…"
 msgstr "Syncing…"
 
-#: src/auth/sign-in/sign-in-screen.tsx:47
+#: src/auth/sign-in/sign-in-screen.tsx:46
 msgid "That doesn't look like an email address."
 msgstr "That doesn't look like an email address."
 
@@ -1155,10 +1159,6 @@ msgstr "waiting for you today"
 #: src/settings/account/account-screen.tsx:47
 msgid "Ways you can get into this account."
 msgstr "Ways you can get into this account."
-
-#: src/auth/sign-in/sign-in-screen.tsx:37
-msgid "Welcome back"
-msgstr "Welcome back"
 
 #: src/repertoire/repertoire-landing.tsx:28
 msgid "What you intend to play, and how well you know it."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -107,7 +107,7 @@ msgstr "{rate} adherence over {games} judged games · prep runs {depth} moves de
 msgid "{rate} of {count, plural, one {# game} other {# games}}"
 msgstr "{rate} of {count, plural, one {# game} other {# games}}"
 
-#: src/games/open-game/game-analysis.tsx:22
+#: src/games/open-game/game-analysis.tsx:30
 msgid "{white} vs {black}"
 msgstr "{white} vs {black}"
 
@@ -115,7 +115,10 @@ msgstr "{white} vs {black}"
 msgid "A finding needs enough games to be more than chance: results and openings speak after a few dozen games, mistake patterns after a handful of analysed ones, book findings once games are judged against a repertoire. Sync, analyse a few, and the first one shows up here."
 msgstr "A finding needs enough games to be more than chance: results and openings speak after a few dozen games, mistake patterns after a handful of analysed ones, book findings once games are judged against a repertoire. Sync, analyse a few, and the first one shows up here."
 
-#: src/app-shell/user-menu.tsx:19
+#: src/app-shell/user-menu.tsx:20
+#: src/routes/_app/settings/account.tsx:7
+#: src/settings/account/account-screen.tsx:34
+#: src/test/routes.tsx:175
 msgid "Account"
 msgstr "Account"
 
@@ -215,6 +218,10 @@ msgstr "Bullet"
 msgid "Chapter"
 msgstr "Chapter"
 
+#: src/settings/account/account-screen.tsx:53
+msgid "Chess.com and Lichess are game sources, not sign-in methods. They live under Import."
+msgstr "Chess.com and Lichess are game sources, not sign-in methods. They live under Import."
+
 #: src/games/import/sources.ts:58
 msgid "Chess.com username"
 msgstr "Chess.com username"
@@ -241,10 +248,18 @@ msgstr "Compare all phases"
 msgid "Connect an account"
 msgstr "Connect an account"
 
+#: src/settings/account/account-screen.tsx:50
+msgid "Connected — you can sign in with Google."
+msgstr "Connected — you can sign in with Google."
+
 #: src/drill/drill.tsx:55
 #: src/repertoire/repertoire-practice.tsx:65
 msgid "Continue"
 msgstr "Continue"
+
+#: src/auth/sign-in/sign-in-screen.tsx:44
+msgid "Continue with Google"
+msgstr "Continue with Google"
 
 #: src/repertoire/repertoire-practice.tsx:62
 msgid "Correct."
@@ -254,7 +269,7 @@ msgstr "Correct."
 msgid "Correspondence"
 msgstr "Correspondence"
 
-#: src/games/open-game/game-analysis.tsx:21
+#: src/games/open-game/game-analysis.tsx:29
 #: src/games/request-analysis/analysis-status.tsx:12
 msgid "Couldn't load analysis."
 msgstr "Couldn't load analysis."
@@ -287,13 +302,21 @@ msgstr "Couldn't load this repertoire."
 msgid "Couldn't load your repertoire."
 msgstr "Couldn't load your repertoire."
 
+#: src/settings/account/account-screen.tsx:48
+msgid "Couldn't load your sign-in methods."
+msgstr "Couldn't load your sign-in methods."
+
 #: src/games/import/sync-games-button.tsx:24
 msgid "Couldn't reach that account"
 msgstr "Couldn't reach that account"
 
-#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr "Couldn't reach the server. Try again in a moment."
+
+#: src/settings/account/account-screen.tsx:45
+msgid "Couldn't save that. Try again."
+msgstr "Couldn't save that. Try again."
 
 #: src/repertoire/chapter-study.tsx:71
 msgid "Current line"
@@ -314,7 +337,7 @@ msgid "Draw"
 msgstr "Draw"
 
 #: src/drill/drill.tsx:44
-#: src/test/routes.tsx:101
+#: src/test/routes.tsx:102
 msgid "Drill"
 msgstr "Drill"
 
@@ -338,9 +361,14 @@ msgstr "Drills from the mistakes that cost you"
 msgid "Due now"
 msgstr "Due now"
 
-#: src/auth/sign-in/sign-in-screen.tsx:30
+#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/settings/account/account-screen.tsx:40
 msgid "Email"
 msgstr "Email"
+
+#: src/settings/account/account-screen.tsx:51
+msgid "Email and password"
+msgstr "Email and password"
 
 #: src/drill/drill.tsx:56
 msgid "End session"
@@ -350,11 +378,15 @@ msgstr "End session"
 msgid "endgame"
 msgstr "endgame"
 
-#: src/auth/sign-in/sign-in-screen.tsx:36
+#: src/settings/account/account-screen.tsx:39
+msgid "Enter a name."
+msgstr "Enter a name."
+
+#: src/auth/sign-in/sign-in-screen.tsx:41
 msgid "Enter your email."
 msgstr "Enter your email."
 
-#: src/auth/sign-in/sign-in-screen.tsx:38
+#: src/auth/sign-in/sign-in-screen.tsx:43
 msgid "Enter your password."
 msgstr "Enter your password."
 
@@ -423,7 +455,7 @@ msgstr "Game phases"
 #: src/dashboard/dashboard.tsx:23
 #: src/games/games-list.tsx:20
 #: src/routes/_app/games.tsx:6
-#: src/test/routes.tsx:75
+#: src/test/routes.tsx:76
 msgid "Games"
 msgstr "Games"
 
@@ -435,9 +467,25 @@ msgstr "Games pages"
 msgid "Good"
 msgstr "Good"
 
+#: src/settings/account/account-screen.tsx:49
+msgid "Google"
+msgstr "Google"
+
+#: src/auth/sign-in/sign-in-screen.tsx:47
+msgid "Google sign-in didn't complete. Try again."
+msgstr "Google sign-in didn't complete. Try again."
+
+#: src/auth/sign-in/sign-in-screen.tsx:46
+msgid "Google sign-in was cancelled."
+msgstr "Google sign-in was cancelled."
+
 #: src/games/import/sources.ts:81
 msgid "Got them — opening your games."
 msgstr "Got them — opening your games."
+
+#: src/settings/account/account-screen.tsx:38
+msgid "How you're shown in the app."
+msgstr "How you're shown in the app."
 
 #: src/games/import/sources.ts:79
 msgid "Import"
@@ -464,11 +512,11 @@ msgid "Inaccuracy"
 msgstr "Inaccuracy"
 
 #: src/insights/insights.tsx:40
-#: src/test/routes.tsx:143
+#: src/test/routes.tsx:144
 msgid "Insights"
 msgstr "Insights"
 
-#: src/auth/sign-in/sign-in-screen.tsx:34
+#: src/auth/sign-in/sign-in-screen.tsx:39
 msgid "Invalid email or password."
 msgstr "Invalid email or password."
 
@@ -528,7 +576,7 @@ msgstr "Lichess username"
 msgid "Loading the chapter…"
 msgstr "Loading the chapter…"
 
-#: src/games/open-game/game-analysis.tsx:20
+#: src/games/open-game/game-analysis.tsx:28
 msgid "Loading the game…"
 msgstr "Loading the game…"
 
@@ -590,6 +638,10 @@ msgstr "Move insight"
 #: src/repertoire/chapter-study.tsx:57
 msgid "Move navigation"
 msgstr "Move navigation"
+
+#: src/settings/account/account-screen.tsx:37
+msgid "Name"
+msgstr "Name"
 
 #: src/drill/drill-queue-panel.tsx:19
 msgid "new"
@@ -703,7 +755,11 @@ msgstr "Opponent moves your repertoire has no answer to, most frequent first. Co
 msgid "Opponent plays:"
 msgstr "Opponent plays:"
 
-#: src/auth/sign-in/sign-in-screen.tsx:31
+#: src/auth/sign-in/sign-in-screen.tsx:45
+msgid "or"
+msgstr "or"
+
+#: src/auth/sign-in/sign-in-screen.tsx:36
 msgid "Password"
 msgstr "Password"
 
@@ -772,6 +828,10 @@ msgstr "Previous"
 msgid "Previous move"
 msgstr "Previous move"
 
+#: src/settings/account/account-screen.tsx:36
+msgid "Profile"
+msgstr "Profile"
+
 #: src/drill/drill.tsx:57
 #: src/repertoire/repertoire-practice.tsx:71
 msgid "Progress"
@@ -801,7 +861,7 @@ msgstr "Reload"
 
 #: src/repertoire/repertoire-landing.tsx:27
 #: src/routes/_app/repertoire.tsx:9
-#: src/test/routes.tsx:111
+#: src/test/routes.tsx:112
 msgid "Repertoire"
 msgstr "Repertoire"
 
@@ -834,6 +894,18 @@ msgstr "Right now: {games} games imported, {analysed} deeply analysed."
 msgid "Right."
 msgstr "Right."
 
+#: src/settings/account/account-screen.tsx:42
+msgid "Save"
+msgstr "Save"
+
+#: src/settings/account/account-screen.tsx:44
+msgid "Saved."
+msgstr "Saved."
+
+#: src/settings/account/account-screen.tsx:43
+msgid "Saving…"
+msgstr "Saving…"
+
 #: src/insights/finding-views.tsx:502
 msgid "Score"
 msgstr "Score"
@@ -855,27 +927,41 @@ msgstr "Seen before"
 msgid "Session complete"
 msgstr "Session complete"
 
+#: src/settings/account/account-screen.tsx:52
+msgid "Set — you can sign in with your email and password."
+msgstr "Set — you can sign in with your email and password."
+
+#: src/app-shell/user-menu.tsx:21
+#: src/routes/_app/settings.tsx:10
+#: src/test/routes.tsx:160
+msgid "Settings"
+msgstr "Settings"
+
 #: src/games/view-analysis/move-insight.tsx:25
 msgid "Show the engine's move on the board"
 msgstr "Show the engine's move on the board"
 
-#: src/auth/sign-in/sign-in-screen.tsx:32
+#: src/auth/sign-in/sign-in-screen.tsx:37
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/auth/sign-in/sign-in-screen.tsx:29
+#: src/auth/sign-in/sign-in-screen.tsx:34
 msgid "Sign in to your VelaChess instance."
 msgstr "Sign in to your VelaChess instance."
 
-#: src/app-shell/user-menu.tsx:20
+#: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/auth/sign-in/sign-in-screen.tsx:33
+#: src/settings/account/account-screen.tsx:46
+msgid "Sign-in methods"
+msgstr "Sign-in methods"
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
 msgid "Signing in…"
 msgstr "Signing in…"
 
-#: src/app-shell/user-menu.tsx:21
+#: src/app-shell/user-menu.tsx:23
 msgid "Signing out…"
 msgstr "Signing out…"
 
@@ -925,7 +1011,7 @@ msgstr "Synced a moment ago"
 msgid "Syncing…"
 msgstr "Syncing…"
 
-#: src/auth/sign-in/sign-in-screen.tsx:37
+#: src/auth/sign-in/sign-in-screen.tsx:42
 msgid "That doesn't look like an email address."
 msgstr "That doesn't look like an email address."
 
@@ -1053,7 +1139,11 @@ msgstr "View games"
 msgid "waiting for you today"
 msgstr "waiting for you today"
 
-#: src/auth/sign-in/sign-in-screen.tsx:28
+#: src/settings/account/account-screen.tsx:47
+msgid "Ways you can get into this account."
+msgstr "Ways you can get into this account."
+
+#: src/auth/sign-in/sign-in-screen.tsx:33
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -1157,6 +1247,10 @@ msgstr "Your {phase} is your most solid stretch"
 msgid "Your book, from your own play"
 msgstr "Your book, from your own play"
 
+#: src/settings/account/account-screen.tsx:41
+msgid "Your email is tied to how you signed up and can't be changed here."
+msgstr "Your email is tied to how you signed up and can't be changed here."
+
 #: src/onboarding/steps.tsx:18
 msgid "Your games are the syllabus"
 msgstr "Your games are the syllabus"
@@ -1168,6 +1262,10 @@ msgstr "Your games, your repertoire, your mistakes."
 #: src/onboarding/onboarding-dialog.tsx:26
 msgid "Your handle is all it takes. We read the public archive and stop there."
 msgstr "Your handle is all it takes. We read the public archive and stop there."
+
+#: src/settings/account/account-screen.tsx:35
+msgid "Your identity on this instance, and how you sign in to it."
+msgstr "Your identity on this instance, and how you sign in to it."
 
 #: src/insights/finding-views.tsx:498
 msgid "Your last {n} games are a clear step up"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -107,6 +107,11 @@ msgstr ""
 msgid "{rate} of {count, plural, one {# game} other {# games}}"
 msgstr ""
 
+#: src/games/import/sync-games-button.tsx:31
+#: src/games/request-analysis/analysis-status.tsx:19
+msgid "{seconds, plural, one {Try again in # second.} other {Try again in # seconds.}}"
+msgstr ""
+
 #: src/games/open-game/game-analysis.tsx:30
 msgid "{white} vs {black}"
 msgstr ""
@@ -128,6 +133,10 @@ msgstr ""
 
 #: src/games/import/sync-games-button.tsx:20
 msgid "Already up to date"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:52
+msgid "An account already exists with that email. Sign in with your password instead."
 msgstr ""
 
 #: src/shared/ui/route-error.tsx:15
@@ -1107,11 +1116,6 @@ msgstr ""
 
 #: src/shared/ui/route-error.tsx:16
 msgid "Try again"
-msgstr ""
-
-#: src/games/import/sync-games-button.tsx:31
-#: src/games/request-analysis/analysis-status.tsx:19
-msgid "Try again in {seconds} seconds."
 msgstr ""
 
 #: src/games/import/sync-games-button.tsx:25

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -134,7 +134,7 @@ msgstr ""
 msgid "An unexpected error interrupted this screen."
 msgstr ""
 
-#: src/games/request-analysis/analysis-status.tsx:16
+#: src/games/request-analysis/analysis-status.tsx:17
 msgid "Analyzing move {graded} of {total}…"
 msgstr ""
 
@@ -1079,6 +1079,10 @@ msgstr ""
 msgid "too few moves to judge"
 msgstr ""
 
+#: src/games/request-analysis/analysis-status.tsx:13
+msgid "Too many analyses at once."
+msgstr ""
+
 #: src/insights/finding-views.tsx:98
 msgid "Train the moves you missed"
 msgstr ""
@@ -1095,6 +1099,11 @@ msgstr ""
 
 #: src/shared/ui/route-error.tsx:16
 msgid "Try again"
+msgstr ""
+
+#: src/games/import/sync-games-button.tsx:31
+#: src/games/request-analysis/analysis-status.tsx:19
+msgid "Try again in {seconds} seconds."
 msgstr ""
 
 #: src/games/import/sync-games-button.tsx:25

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -107,7 +107,7 @@ msgstr ""
 msgid "{rate} of {count, plural, one {# game} other {# games}}"
 msgstr ""
 
-#: src/games/open-game/game-analysis.tsx:22
+#: src/games/open-game/game-analysis.tsx:30
 msgid "{white} vs {black}"
 msgstr ""
 
@@ -115,7 +115,10 @@ msgstr ""
 msgid "A finding needs enough games to be more than chance: results and openings speak after a few dozen games, mistake patterns after a handful of analysed ones, book findings once games are judged against a repertoire. Sync, analyse a few, and the first one shows up here."
 msgstr ""
 
-#: src/app-shell/user-menu.tsx:19
+#: src/app-shell/user-menu.tsx:20
+#: src/routes/_app/settings/account.tsx:7
+#: src/settings/account/account-screen.tsx:34
+#: src/test/routes.tsx:175
 msgid "Account"
 msgstr ""
 
@@ -215,6 +218,10 @@ msgstr ""
 msgid "Chapter"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:53
+msgid "Chess.com and Lichess are game sources, not sign-in methods. They live under Import."
+msgstr ""
+
 #: src/games/import/sources.ts:58
 msgid "Chess.com username"
 msgstr ""
@@ -241,9 +248,17 @@ msgstr ""
 msgid "Connect an account"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:50
+msgid "Connected — you can sign in with Google."
+msgstr ""
+
 #: src/drill/drill.tsx:55
 #: src/repertoire/repertoire-practice.tsx:65
 msgid "Continue"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:44
+msgid "Continue with Google"
 msgstr ""
 
 #: src/repertoire/repertoire-practice.tsx:62
@@ -254,7 +269,7 @@ msgstr ""
 msgid "Correspondence"
 msgstr ""
 
-#: src/games/open-game/game-analysis.tsx:21
+#: src/games/open-game/game-analysis.tsx:29
 #: src/games/request-analysis/analysis-status.tsx:12
 msgid "Couldn't load analysis."
 msgstr ""
@@ -287,12 +302,20 @@ msgstr ""
 msgid "Couldn't load your repertoire."
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:48
+msgid "Couldn't load your sign-in methods."
+msgstr ""
+
 #: src/games/import/sync-games-button.tsx:24
 msgid "Couldn't reach that account"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Couldn't reach the server. Try again in a moment."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:45
+msgid "Couldn't save that. Try again."
 msgstr ""
 
 #: src/repertoire/chapter-study.tsx:71
@@ -314,7 +337,7 @@ msgid "Draw"
 msgstr ""
 
 #: src/drill/drill.tsx:44
-#: src/test/routes.tsx:101
+#: src/test/routes.tsx:102
 msgid "Drill"
 msgstr ""
 
@@ -338,8 +361,13 @@ msgstr ""
 msgid "Due now"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:30
+#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/settings/account/account-screen.tsx:40
 msgid "Email"
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:51
+msgid "Email and password"
 msgstr ""
 
 #: src/drill/drill.tsx:56
@@ -350,11 +378,15 @@ msgstr ""
 msgid "endgame"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:36
+#: src/settings/account/account-screen.tsx:39
+msgid "Enter a name."
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:41
 msgid "Enter your email."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:38
+#: src/auth/sign-in/sign-in-screen.tsx:43
 msgid "Enter your password."
 msgstr ""
 
@@ -423,7 +455,7 @@ msgstr ""
 #: src/dashboard/dashboard.tsx:23
 #: src/games/games-list.tsx:20
 #: src/routes/_app/games.tsx:6
-#: src/test/routes.tsx:75
+#: src/test/routes.tsx:76
 msgid "Games"
 msgstr ""
 
@@ -435,8 +467,24 @@ msgstr ""
 msgid "Good"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:49
+msgid "Google"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:47
+msgid "Google sign-in didn't complete. Try again."
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:46
+msgid "Google sign-in was cancelled."
+msgstr ""
+
 #: src/games/import/sources.ts:81
 msgid "Got them — opening your games."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:38
+msgid "How you're shown in the app."
 msgstr ""
 
 #: src/games/import/sources.ts:79
@@ -464,11 +512,11 @@ msgid "Inaccuracy"
 msgstr ""
 
 #: src/insights/insights.tsx:40
-#: src/test/routes.tsx:143
+#: src/test/routes.tsx:144
 msgid "Insights"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:34
+#: src/auth/sign-in/sign-in-screen.tsx:39
 msgid "Invalid email or password."
 msgstr ""
 
@@ -528,7 +576,7 @@ msgstr ""
 msgid "Loading the chapter…"
 msgstr ""
 
-#: src/games/open-game/game-analysis.tsx:20
+#: src/games/open-game/game-analysis.tsx:28
 msgid "Loading the game…"
 msgstr ""
 
@@ -589,6 +637,10 @@ msgstr ""
 #: src/games/open-game/replay-controls.tsx:11
 #: src/repertoire/chapter-study.tsx:57
 msgid "Move navigation"
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:37
+msgid "Name"
 msgstr ""
 
 #: src/drill/drill-queue-panel.tsx:19
@@ -703,7 +755,11 @@ msgstr ""
 msgid "Opponent plays:"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:31
+#: src/auth/sign-in/sign-in-screen.tsx:45
+msgid "or"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:36
 msgid "Password"
 msgstr ""
 
@@ -772,6 +828,10 @@ msgstr ""
 msgid "Previous move"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:36
+msgid "Profile"
+msgstr ""
+
 #: src/drill/drill.tsx:57
 #: src/repertoire/repertoire-practice.tsx:71
 msgid "Progress"
@@ -801,7 +861,7 @@ msgstr ""
 
 #: src/repertoire/repertoire-landing.tsx:27
 #: src/routes/_app/repertoire.tsx:9
-#: src/test/routes.tsx:111
+#: src/test/routes.tsx:112
 msgid "Repertoire"
 msgstr ""
 
@@ -834,6 +894,18 @@ msgstr ""
 msgid "Right."
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:42
+msgid "Save"
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:44
+msgid "Saved."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:43
+msgid "Saving…"
+msgstr ""
+
 #: src/insights/finding-views.tsx:502
 msgid "Score"
 msgstr ""
@@ -855,27 +927,41 @@ msgstr ""
 msgid "Session complete"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:52
+msgid "Set — you can sign in with your email and password."
+msgstr ""
+
+#: src/app-shell/user-menu.tsx:21
+#: src/routes/_app/settings.tsx:10
+#: src/test/routes.tsx:160
+msgid "Settings"
+msgstr ""
+
 #: src/games/view-analysis/move-insight.tsx:25
 msgid "Show the engine's move on the board"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:32
+#: src/auth/sign-in/sign-in-screen.tsx:37
 msgid "Sign in"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:29
+#: src/auth/sign-in/sign-in-screen.tsx:34
 msgid "Sign in to your VelaChess instance."
 msgstr ""
 
-#: src/app-shell/user-menu.tsx:20
+#: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:33
+#: src/settings/account/account-screen.tsx:46
+msgid "Sign-in methods"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
 msgid "Signing in…"
 msgstr ""
 
-#: src/app-shell/user-menu.tsx:21
+#: src/app-shell/user-menu.tsx:23
 msgid "Signing out…"
 msgstr ""
 
@@ -925,7 +1011,7 @@ msgstr ""
 msgid "Syncing…"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:37
+#: src/auth/sign-in/sign-in-screen.tsx:42
 msgid "That doesn't look like an email address."
 msgstr ""
 
@@ -1053,7 +1139,11 @@ msgstr ""
 msgid "waiting for you today"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:28
+#: src/settings/account/account-screen.tsx:47
+msgid "Ways you can get into this account."
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:33
 msgid "Welcome back"
 msgstr ""
 
@@ -1157,6 +1247,10 @@ msgstr ""
 msgid "Your book, from your own play"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:41
+msgid "Your email is tied to how you signed up and can't be changed here."
+msgstr ""
+
 #: src/onboarding/steps.tsx:18
 msgid "Your games are the syllabus"
 msgstr ""
@@ -1167,6 +1261,10 @@ msgstr ""
 
 #: src/onboarding/onboarding-dialog.tsx:26
 msgid "Your handle is all it takes. We read the public archive and stop there."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:35
+msgid "Your identity on this instance, and how you sign in to it."
 msgstr ""
 
 #: src/insights/finding-views.tsx:498

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -257,10 +257,6 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:44
-msgid "Continue with Google"
-msgstr ""
-
 #: src/repertoire/repertoire-practice.tsx:62
 msgid "Correct."
 msgstr ""
@@ -310,7 +306,7 @@ msgstr ""
 msgid "Couldn't reach that account"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:40
+#: src/auth/sign-in/sign-in-screen.tsx:45
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr ""
 
@@ -361,7 +357,7 @@ msgstr ""
 msgid "Due now"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/auth/sign-in/sign-in-screen.tsx:40
 #: src/settings/account/account-screen.tsx:40
 msgid "Email"
 msgstr ""
@@ -382,11 +378,15 @@ msgstr ""
 msgid "Enter a name."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:41
+#: src/auth/sign-in/sign-in-screen.tsx:39
+msgid "Enter your email below to login to your account"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:46
 msgid "Enter your email."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:43
+#: src/auth/sign-in/sign-in-screen.tsx:48
 msgid "Enter your password."
 msgstr ""
 
@@ -471,11 +471,11 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:47
+#: src/auth/sign-in/sign-in-screen.tsx:52
 msgid "Google sign-in didn't complete. Try again."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:46
+#: src/auth/sign-in/sign-in-screen.tsx:51
 msgid "Google sign-in was cancelled."
 msgstr ""
 
@@ -516,7 +516,7 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:39
+#: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Invalid email or password."
 msgstr ""
 
@@ -583,6 +583,22 @@ msgstr ""
 #: src/drill/drill.tsx:46
 #: src/repertoire/repertoire-practice.tsx:53
 msgid "Loading…"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:43
+msgid "Logging in…"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:42
+msgid "Login"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:49
+msgid "Login with Google"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
+msgid "Login with your Google account"
 msgstr ""
 
 #: src/insights/finding-views.tsx:99
@@ -755,11 +771,11 @@ msgstr ""
 msgid "Opponent plays:"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:45
-msgid "or"
+#: src/auth/sign-in/sign-in-screen.tsx:50
+msgid "Or continue with"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:36
+#: src/auth/sign-in/sign-in-screen.tsx:41
 msgid "Password"
 msgstr ""
 
@@ -941,24 +957,12 @@ msgstr ""
 msgid "Show the engine's move on the board"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:37
-msgid "Sign in"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:34
-msgid "Sign in to your VelaChess instance."
-msgstr ""
-
 #: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr ""
 
 #: src/settings/account/account-screen.tsx:46
 msgid "Sign-in methods"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:38
-msgid "Signing in…"
 msgstr ""
 
 #: src/app-shell/user-menu.tsx:23
@@ -1011,7 +1015,7 @@ msgstr ""
 msgid "Syncing…"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:42
+#: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "That doesn't look like an email address."
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 msgid "Ways you can get into this account."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:33
+#: src/auth/sign-in/sign-in-screen.tsx:37
 msgid "Welcome back"
 msgstr ""
 

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -257,6 +257,18 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
+#: src/auth/sign-in/sign-in-screen.tsx:36
+msgid "Continue to VelaChess"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:48
+msgid "Continue with Google"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:37
+msgid "Continue with Google or sign in with your account credentials."
+msgstr ""
+
 #: src/repertoire/repertoire-practice.tsx:62
 msgid "Correct."
 msgstr ""
@@ -306,7 +318,7 @@ msgstr ""
 msgid "Couldn't reach that account"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:45
+#: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr ""
 
@@ -357,7 +369,7 @@ msgstr ""
 msgid "Due now"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:40
+#: src/auth/sign-in/sign-in-screen.tsx:39
 #: src/settings/account/account-screen.tsx:40
 msgid "Email"
 msgstr ""
@@ -378,15 +390,11 @@ msgstr ""
 msgid "Enter a name."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:39
-msgid "Enter your email below to login to your account"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:46
+#: src/auth/sign-in/sign-in-screen.tsx:45
 msgid "Enter your email."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:48
+#: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "Enter your password."
 msgstr ""
 
@@ -471,11 +479,11 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:52
+#: src/auth/sign-in/sign-in-screen.tsx:51
 msgid "Google sign-in didn't complete. Try again."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:51
+#: src/auth/sign-in/sign-in-screen.tsx:50
 msgid "Google sign-in was cancelled."
 msgstr ""
 
@@ -516,7 +524,7 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:44
+#: src/auth/sign-in/sign-in-screen.tsx:43
 msgid "Invalid email or password."
 msgstr ""
 
@@ -583,22 +591,6 @@ msgstr ""
 #: src/drill/drill.tsx:46
 #: src/repertoire/repertoire-practice.tsx:53
 msgid "Loading…"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:43
-msgid "Logging in…"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:42
-msgid "Login"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:49
-msgid "Login with Google"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:38
-msgid "Login with your Google account"
 msgstr ""
 
 #: src/insights/finding-views.tsx:99
@@ -771,11 +763,11 @@ msgstr ""
 msgid "Opponent plays:"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:50
+#: src/auth/sign-in/sign-in-screen.tsx:49
 msgid "Or continue with"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:41
+#: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Password"
 msgstr ""
 
@@ -957,12 +949,24 @@ msgstr ""
 msgid "Show the engine's move on the board"
 msgstr ""
 
+#: src/auth/sign-in/sign-in-screen.tsx:41
+msgid "Sign in"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
+msgid "Sign in with your account credentials."
+msgstr ""
+
 #: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr ""
 
 #: src/settings/account/account-screen.tsx:46
 msgid "Sign-in methods"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:42
+msgid "Signing in…"
 msgstr ""
 
 #: src/app-shell/user-menu.tsx:23
@@ -1015,7 +1019,7 @@ msgstr ""
 msgid "Syncing…"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:47
+#: src/auth/sign-in/sign-in-screen.tsx:46
 msgid "That doesn't look like an email address."
 msgstr ""
 
@@ -1154,10 +1158,6 @@ msgstr ""
 
 #: src/settings/account/account-screen.tsx:47
 msgid "Ways you can get into this account."
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:37
-msgid "Welcome back"
 msgstr ""
 
 #: src/repertoire/repertoire-landing.tsx:28

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -107,6 +107,11 @@ msgstr ""
 msgid "{rate} of {count, plural, one {# game} other {# games}}"
 msgstr ""
 
+#: src/games/import/sync-games-button.tsx:31
+#: src/games/request-analysis/analysis-status.tsx:19
+msgid "{seconds, plural, one {Try again in # second.} other {Try again in # seconds.}}"
+msgstr ""
+
 #: src/games/open-game/game-analysis.tsx:30
 msgid "{white} vs {black}"
 msgstr ""
@@ -128,6 +133,10 @@ msgstr ""
 
 #: src/games/import/sync-games-button.tsx:20
 msgid "Already up to date"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:52
+msgid "An account already exists with that email. Sign in with your password instead."
 msgstr ""
 
 #: src/shared/ui/route-error.tsx:15
@@ -1107,11 +1116,6 @@ msgstr ""
 
 #: src/shared/ui/route-error.tsx:16
 msgid "Try again"
-msgstr ""
-
-#: src/games/import/sync-games-button.tsx:31
-#: src/games/request-analysis/analysis-status.tsx:19
-msgid "Try again in {seconds} seconds."
 msgstr ""
 
 #: src/games/import/sync-games-button.tsx:25

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -134,7 +134,7 @@ msgstr ""
 msgid "An unexpected error interrupted this screen."
 msgstr ""
 
-#: src/games/request-analysis/analysis-status.tsx:16
+#: src/games/request-analysis/analysis-status.tsx:17
 msgid "Analyzing move {graded} of {total}…"
 msgstr ""
 
@@ -1079,6 +1079,10 @@ msgstr ""
 msgid "too few moves to judge"
 msgstr ""
 
+#: src/games/request-analysis/analysis-status.tsx:13
+msgid "Too many analyses at once."
+msgstr ""
+
 #: src/insights/finding-views.tsx:98
 msgid "Train the moves you missed"
 msgstr ""
@@ -1095,6 +1099,11 @@ msgstr ""
 
 #: src/shared/ui/route-error.tsx:16
 msgid "Try again"
+msgstr ""
+
+#: src/games/import/sync-games-button.tsx:31
+#: src/games/request-analysis/analysis-status.tsx:19
+msgid "Try again in {seconds} seconds."
 msgstr ""
 
 #: src/games/import/sync-games-button.tsx:25

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -107,7 +107,7 @@ msgstr ""
 msgid "{rate} of {count, plural, one {# game} other {# games}}"
 msgstr ""
 
-#: src/games/open-game/game-analysis.tsx:22
+#: src/games/open-game/game-analysis.tsx:30
 msgid "{white} vs {black}"
 msgstr ""
 
@@ -115,7 +115,10 @@ msgstr ""
 msgid "A finding needs enough games to be more than chance: results and openings speak after a few dozen games, mistake patterns after a handful of analysed ones, book findings once games are judged against a repertoire. Sync, analyse a few, and the first one shows up here."
 msgstr ""
 
-#: src/app-shell/user-menu.tsx:19
+#: src/app-shell/user-menu.tsx:20
+#: src/routes/_app/settings/account.tsx:7
+#: src/settings/account/account-screen.tsx:34
+#: src/test/routes.tsx:175
 msgid "Account"
 msgstr ""
 
@@ -215,6 +218,10 @@ msgstr ""
 msgid "Chapter"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:53
+msgid "Chess.com and Lichess are game sources, not sign-in methods. They live under Import."
+msgstr ""
+
 #: src/games/import/sources.ts:58
 msgid "Chess.com username"
 msgstr ""
@@ -241,9 +248,17 @@ msgstr ""
 msgid "Connect an account"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:50
+msgid "Connected — you can sign in with Google."
+msgstr ""
+
 #: src/drill/drill.tsx:55
 #: src/repertoire/repertoire-practice.tsx:65
 msgid "Continue"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:44
+msgid "Continue with Google"
 msgstr ""
 
 #: src/repertoire/repertoire-practice.tsx:62
@@ -254,7 +269,7 @@ msgstr ""
 msgid "Correspondence"
 msgstr ""
 
-#: src/games/open-game/game-analysis.tsx:21
+#: src/games/open-game/game-analysis.tsx:29
 #: src/games/request-analysis/analysis-status.tsx:12
 msgid "Couldn't load analysis."
 msgstr ""
@@ -287,12 +302,20 @@ msgstr ""
 msgid "Couldn't load your repertoire."
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:48
+msgid "Couldn't load your sign-in methods."
+msgstr ""
+
 #: src/games/import/sync-games-button.tsx:24
 msgid "Couldn't reach that account"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Couldn't reach the server. Try again in a moment."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:45
+msgid "Couldn't save that. Try again."
 msgstr ""
 
 #: src/repertoire/chapter-study.tsx:71
@@ -314,7 +337,7 @@ msgid "Draw"
 msgstr ""
 
 #: src/drill/drill.tsx:44
-#: src/test/routes.tsx:101
+#: src/test/routes.tsx:102
 msgid "Drill"
 msgstr ""
 
@@ -338,8 +361,13 @@ msgstr ""
 msgid "Due now"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:30
+#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/settings/account/account-screen.tsx:40
 msgid "Email"
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:51
+msgid "Email and password"
 msgstr ""
 
 #: src/drill/drill.tsx:56
@@ -350,11 +378,15 @@ msgstr ""
 msgid "endgame"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:36
+#: src/settings/account/account-screen.tsx:39
+msgid "Enter a name."
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:41
 msgid "Enter your email."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:38
+#: src/auth/sign-in/sign-in-screen.tsx:43
 msgid "Enter your password."
 msgstr ""
 
@@ -423,7 +455,7 @@ msgstr ""
 #: src/dashboard/dashboard.tsx:23
 #: src/games/games-list.tsx:20
 #: src/routes/_app/games.tsx:6
-#: src/test/routes.tsx:75
+#: src/test/routes.tsx:76
 msgid "Games"
 msgstr ""
 
@@ -435,8 +467,24 @@ msgstr ""
 msgid "Good"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:49
+msgid "Google"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:47
+msgid "Google sign-in didn't complete. Try again."
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:46
+msgid "Google sign-in was cancelled."
+msgstr ""
+
 #: src/games/import/sources.ts:81
 msgid "Got them — opening your games."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:38
+msgid "How you're shown in the app."
 msgstr ""
 
 #: src/games/import/sources.ts:79
@@ -464,11 +512,11 @@ msgid "Inaccuracy"
 msgstr ""
 
 #: src/insights/insights.tsx:40
-#: src/test/routes.tsx:143
+#: src/test/routes.tsx:144
 msgid "Insights"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:34
+#: src/auth/sign-in/sign-in-screen.tsx:39
 msgid "Invalid email or password."
 msgstr ""
 
@@ -528,7 +576,7 @@ msgstr ""
 msgid "Loading the chapter…"
 msgstr ""
 
-#: src/games/open-game/game-analysis.tsx:20
+#: src/games/open-game/game-analysis.tsx:28
 msgid "Loading the game…"
 msgstr ""
 
@@ -589,6 +637,10 @@ msgstr ""
 #: src/games/open-game/replay-controls.tsx:11
 #: src/repertoire/chapter-study.tsx:57
 msgid "Move navigation"
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:37
+msgid "Name"
 msgstr ""
 
 #: src/drill/drill-queue-panel.tsx:19
@@ -703,7 +755,11 @@ msgstr ""
 msgid "Opponent plays:"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:31
+#: src/auth/sign-in/sign-in-screen.tsx:45
+msgid "or"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:36
 msgid "Password"
 msgstr ""
 
@@ -772,6 +828,10 @@ msgstr ""
 msgid "Previous move"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:36
+msgid "Profile"
+msgstr ""
+
 #: src/drill/drill.tsx:57
 #: src/repertoire/repertoire-practice.tsx:71
 msgid "Progress"
@@ -801,7 +861,7 @@ msgstr ""
 
 #: src/repertoire/repertoire-landing.tsx:27
 #: src/routes/_app/repertoire.tsx:9
-#: src/test/routes.tsx:111
+#: src/test/routes.tsx:112
 msgid "Repertoire"
 msgstr ""
 
@@ -834,6 +894,18 @@ msgstr ""
 msgid "Right."
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:42
+msgid "Save"
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:44
+msgid "Saved."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:43
+msgid "Saving…"
+msgstr ""
+
 #: src/insights/finding-views.tsx:502
 msgid "Score"
 msgstr ""
@@ -855,27 +927,41 @@ msgstr ""
 msgid "Session complete"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:52
+msgid "Set — you can sign in with your email and password."
+msgstr ""
+
+#: src/app-shell/user-menu.tsx:21
+#: src/routes/_app/settings.tsx:10
+#: src/test/routes.tsx:160
+msgid "Settings"
+msgstr ""
+
 #: src/games/view-analysis/move-insight.tsx:25
 msgid "Show the engine's move on the board"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:32
+#: src/auth/sign-in/sign-in-screen.tsx:37
 msgid "Sign in"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:29
+#: src/auth/sign-in/sign-in-screen.tsx:34
 msgid "Sign in to your VelaChess instance."
 msgstr ""
 
-#: src/app-shell/user-menu.tsx:20
+#: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:33
+#: src/settings/account/account-screen.tsx:46
+msgid "Sign-in methods"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
 msgid "Signing in…"
 msgstr ""
 
-#: src/app-shell/user-menu.tsx:21
+#: src/app-shell/user-menu.tsx:23
 msgid "Signing out…"
 msgstr ""
 
@@ -925,7 +1011,7 @@ msgstr ""
 msgid "Syncing…"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:37
+#: src/auth/sign-in/sign-in-screen.tsx:42
 msgid "That doesn't look like an email address."
 msgstr ""
 
@@ -1053,7 +1139,11 @@ msgstr ""
 msgid "waiting for you today"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:28
+#: src/settings/account/account-screen.tsx:47
+msgid "Ways you can get into this account."
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:33
 msgid "Welcome back"
 msgstr ""
 
@@ -1157,6 +1247,10 @@ msgstr ""
 msgid "Your book, from your own play"
 msgstr ""
 
+#: src/settings/account/account-screen.tsx:41
+msgid "Your email is tied to how you signed up and can't be changed here."
+msgstr ""
+
 #: src/onboarding/steps.tsx:18
 msgid "Your games are the syllabus"
 msgstr ""
@@ -1167,6 +1261,10 @@ msgstr ""
 
 #: src/onboarding/onboarding-dialog.tsx:26
 msgid "Your handle is all it takes. We read the public archive and stop there."
+msgstr ""
+
+#: src/settings/account/account-screen.tsx:35
+msgid "Your identity on this instance, and how you sign in to it."
 msgstr ""
 
 #: src/insights/finding-views.tsx:498

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -257,10 +257,6 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:44
-msgid "Continue with Google"
-msgstr ""
-
 #: src/repertoire/repertoire-practice.tsx:62
 msgid "Correct."
 msgstr ""
@@ -310,7 +306,7 @@ msgstr ""
 msgid "Couldn't reach that account"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:40
+#: src/auth/sign-in/sign-in-screen.tsx:45
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr ""
 
@@ -361,7 +357,7 @@ msgstr ""
 msgid "Due now"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:35
+#: src/auth/sign-in/sign-in-screen.tsx:40
 #: src/settings/account/account-screen.tsx:40
 msgid "Email"
 msgstr ""
@@ -382,11 +378,15 @@ msgstr ""
 msgid "Enter a name."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:41
+#: src/auth/sign-in/sign-in-screen.tsx:39
+msgid "Enter your email below to login to your account"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:46
 msgid "Enter your email."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:43
+#: src/auth/sign-in/sign-in-screen.tsx:48
 msgid "Enter your password."
 msgstr ""
 
@@ -471,11 +471,11 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:47
+#: src/auth/sign-in/sign-in-screen.tsx:52
 msgid "Google sign-in didn't complete. Try again."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:46
+#: src/auth/sign-in/sign-in-screen.tsx:51
 msgid "Google sign-in was cancelled."
 msgstr ""
 
@@ -516,7 +516,7 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:39
+#: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Invalid email or password."
 msgstr ""
 
@@ -583,6 +583,22 @@ msgstr ""
 #: src/drill/drill.tsx:46
 #: src/repertoire/repertoire-practice.tsx:53
 msgid "Loading…"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:43
+msgid "Logging in…"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:42
+msgid "Login"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:49
+msgid "Login with Google"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
+msgid "Login with your Google account"
 msgstr ""
 
 #: src/insights/finding-views.tsx:99
@@ -755,11 +771,11 @@ msgstr ""
 msgid "Opponent plays:"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:45
-msgid "or"
+#: src/auth/sign-in/sign-in-screen.tsx:50
+msgid "Or continue with"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:36
+#: src/auth/sign-in/sign-in-screen.tsx:41
 msgid "Password"
 msgstr ""
 
@@ -941,24 +957,12 @@ msgstr ""
 msgid "Show the engine's move on the board"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:37
-msgid "Sign in"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:34
-msgid "Sign in to your VelaChess instance."
-msgstr ""
-
 #: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr ""
 
 #: src/settings/account/account-screen.tsx:46
 msgid "Sign-in methods"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:38
-msgid "Signing in…"
 msgstr ""
 
 #: src/app-shell/user-menu.tsx:23
@@ -1011,7 +1015,7 @@ msgstr ""
 msgid "Syncing…"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:42
+#: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "That doesn't look like an email address."
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 msgid "Ways you can get into this account."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:33
+#: src/auth/sign-in/sign-in-screen.tsx:37
 msgid "Welcome back"
 msgstr ""
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -257,6 +257,18 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
+#: src/auth/sign-in/sign-in-screen.tsx:36
+msgid "Continue to VelaChess"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:48
+msgid "Continue with Google"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:37
+msgid "Continue with Google or sign in with your account credentials."
+msgstr ""
+
 #: src/repertoire/repertoire-practice.tsx:62
 msgid "Correct."
 msgstr ""
@@ -306,7 +318,7 @@ msgstr ""
 msgid "Couldn't reach that account"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:45
+#: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr ""
 
@@ -357,7 +369,7 @@ msgstr ""
 msgid "Due now"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:40
+#: src/auth/sign-in/sign-in-screen.tsx:39
 #: src/settings/account/account-screen.tsx:40
 msgid "Email"
 msgstr ""
@@ -378,15 +390,11 @@ msgstr ""
 msgid "Enter a name."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:39
-msgid "Enter your email below to login to your account"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:46
+#: src/auth/sign-in/sign-in-screen.tsx:45
 msgid "Enter your email."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:48
+#: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "Enter your password."
 msgstr ""
 
@@ -471,11 +479,11 @@ msgstr ""
 msgid "Google"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:52
+#: src/auth/sign-in/sign-in-screen.tsx:51
 msgid "Google sign-in didn't complete. Try again."
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:51
+#: src/auth/sign-in/sign-in-screen.tsx:50
 msgid "Google sign-in was cancelled."
 msgstr ""
 
@@ -516,7 +524,7 @@ msgstr ""
 msgid "Insights"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:44
+#: src/auth/sign-in/sign-in-screen.tsx:43
 msgid "Invalid email or password."
 msgstr ""
 
@@ -583,22 +591,6 @@ msgstr ""
 #: src/drill/drill.tsx:46
 #: src/repertoire/repertoire-practice.tsx:53
 msgid "Loading…"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:43
-msgid "Logging in…"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:42
-msgid "Login"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:49
-msgid "Login with Google"
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:38
-msgid "Login with your Google account"
 msgstr ""
 
 #: src/insights/finding-views.tsx:99
@@ -771,11 +763,11 @@ msgstr ""
 msgid "Opponent plays:"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:50
+#: src/auth/sign-in/sign-in-screen.tsx:49
 msgid "Or continue with"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:41
+#: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Password"
 msgstr ""
 
@@ -957,12 +949,24 @@ msgstr ""
 msgid "Show the engine's move on the board"
 msgstr ""
 
+#: src/auth/sign-in/sign-in-screen.tsx:41
+msgid "Sign in"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:38
+msgid "Sign in with your account credentials."
+msgstr ""
+
 #: src/app-shell/user-menu.tsx:22
 msgid "Sign out"
 msgstr ""
 
 #: src/settings/account/account-screen.tsx:46
 msgid "Sign-in methods"
+msgstr ""
+
+#: src/auth/sign-in/sign-in-screen.tsx:42
+msgid "Signing in…"
 msgstr ""
 
 #: src/app-shell/user-menu.tsx:23
@@ -1015,7 +1019,7 @@ msgstr ""
 msgid "Syncing…"
 msgstr ""
 
-#: src/auth/sign-in/sign-in-screen.tsx:47
+#: src/auth/sign-in/sign-in-screen.tsx:46
 msgid "That doesn't look like an email address."
 msgstr ""
 
@@ -1154,10 +1158,6 @@ msgstr ""
 
 #: src/settings/account/account-screen.tsx:47
 msgid "Ways you can get into this account."
-msgstr ""
-
-#: src/auth/sign-in/sign-in-screen.tsx:37
-msgid "Welcome back"
 msgstr ""
 
 #: src/repertoire/repertoire-landing.tsx:28

--- a/apps/web/src/routes/_app/settings.tsx
+++ b/apps/web/src/routes/_app/settings.tsx
@@ -1,0 +1,12 @@
+import { msg } from "@lingui/core/macro";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+/**
+ * Settings is a section, not a screen — a real ancestor so the crumb
+ * resolves and so the next section (Connections) nests rather than
+ * re-declares the level.
+ */
+export const Route = createFileRoute("/_app/settings")({
+  staticData: { crumb: msg`Settings` },
+  component: () => <Outlet />,
+});

--- a/apps/web/src/routes/_app/settings/account.tsx
+++ b/apps/web/src/routes/_app/settings/account.tsx
@@ -1,0 +1,9 @@
+import { msg } from "@lingui/core/macro";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { AccountScreen } from "../../../settings/account/account-screen.tsx";
+
+export const Route = createFileRoute("/_app/settings/account")({
+  staticData: { crumb: msg`Account` },
+  component: AccountScreen,
+});

--- a/apps/web/src/routes/_app/settings/index.tsx
+++ b/apps/web/src/routes/_app/settings/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * `/settings` has nothing of its own to show while Account is the only
+ * section. A landing page listing one link would be a menu with one item.
+ */
+export const Route = createFileRoute("/_app/settings/")({
+  beforeLoad: () => {
+    throw redirect({ to: "/settings/account", replace: true });
+  },
+});

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -26,7 +26,7 @@ const loginSearchSchema = z.object({
   error: z
     .string()
     .max(64)
-    .regex(/^[a-z_]+$/i, { message: "error must be an OAuth error code" })
+    .regex(/^[a-z0-9_-]+$/i, { message: "error must be an OAuth error code" })
     .optional()
     .catch(undefined),
 });

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -16,6 +16,19 @@ const loginSearchSchema = z.object({
     })
     .optional()
     .catch(undefined),
+  /**
+   * Where a failed Google attempt lands: Better Auth appends `?error=<code>`
+   * when it sends the browser back here (`errorCallbackURL` in
+   * auth/sign-in/social.ts). Bounded to a short token — the value arrives
+   * on the address bar, so it is never rendered, only matched against
+   * codes the screen knows (`oauthErrorCopy`).
+   */
+  error: z
+    .string()
+    .max(64)
+    .regex(/^[a-z_]+$/i, { message: "error must be an OAuth error code" })
+    .optional()
+    .catch(undefined),
 });
 
 export const Route = createFileRoute("/login")({
@@ -30,7 +43,12 @@ export const Route = createFileRoute("/login")({
 });
 
 function LoginRoute() {
-  const { redirect: destination } = Route.useSearch();
+  const { redirect: destination, error } = Route.useSearch();
 
-  return <SignInScreen {...(destination ? { redirect: destination } : {})} />;
+  return (
+    <SignInScreen
+      {...(destination ? { redirect: destination } : {})}
+      {...(error ? { oauthError: error } : {})}
+    />
+  );
 }

--- a/apps/web/src/settings/account/__tests__/account.test.tsx
+++ b/apps/web/src/settings/account/__tests__/account.test.tsx
@@ -1,0 +1,231 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+
+import { renderApp } from "../../../test/render.tsx";
+import { server } from "../../../test/server.ts";
+import {
+  linkedProvidersAre,
+  sessionActive,
+  sessionInactive,
+  TEST_USER,
+} from "../../../test/handlers/auth.ts";
+
+/**
+ * Settings → Account: who you are here, and how you get back in.
+ *
+ * Driven through the real router and the real shell, because half of what
+ * this screen promises is navigational — that the user menu leads here,
+ * that the section is behind the same wall as everything else, and that a
+ * rename shows up in the shell it was performed from.
+ */
+
+describe("reaching the account screen", () => {
+  it("opens from the user menu", async () => {
+    sessionActive();
+
+    const { router, user } = await renderApp({ path: "/" });
+
+    await user.click(await screen.findByRole("button", { name: "Account" }));
+    await user.click(await screen.findByRole("button", { name: "Settings" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/settings/account"));
+    expect(await screen.findByRole("heading", { name: "Account" })).toBeInTheDocument();
+  });
+
+  it("sends /settings to the only section there is", async () => {
+    sessionActive();
+
+    const { router } = await renderApp({ path: "/settings" });
+
+    expect(router.state.location.pathname).toBe("/settings/account");
+  });
+
+  it("is behind the same wall as the rest of the app", async () => {
+    sessionInactive();
+
+    const { router } = await renderApp({ path: "/settings/account" });
+
+    expect(router.state.location.pathname).toBe("/login");
+  });
+});
+
+describe("the profile", () => {
+  it("shows who is signed in", async () => {
+    sessionActive();
+
+    await renderApp({ path: "/settings/account" });
+
+    expect(await screen.findByDisplayValue(TEST_USER.name)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(TEST_USER.email)).toBeInTheDocument();
+  });
+
+  it("will not let the email be edited here", async () => {
+    sessionActive();
+
+    await renderApp({ path: "/settings/account" });
+
+    // Shown because people look for it; disabled because changing it is a
+    // verification flow this build cannot complete. An input that accepts
+    // typing and silently discards it would be the worse answer.
+    const email = await screen.findByLabelText("Email");
+    expect(email).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Your email is tied to how you signed up and can't be changed here.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renames the person, and the shell agrees", async () => {
+    sessionActive();
+
+    const { user } = await renderApp({ path: "/settings/account" });
+
+    const name = await screen.findByLabelText("Name");
+    await user.clear(name);
+    await user.type(name, "Magnus");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Saved.")).toBeInTheDocument();
+
+    // The point of routing the write through the session query: the name
+    // in the shell is the same fact, so it cannot lag behind. Two places
+    // now say "Magnus" — this screen's profile, and the menu — and that
+    // is precisely the assertion.
+    await user.click(screen.getByRole("button", { name: "Account" }));
+    await waitFor(() => expect(screen.getAllByText("Magnus")).toHaveLength(2));
+  });
+
+  it("refuses an empty name instead of saving one", async () => {
+    sessionActive();
+
+    let wrote = false;
+    server.use(
+      http.post("/api/auth/update-user", () => {
+        wrote = true;
+        return HttpResponse.json({ status: true });
+      }),
+    );
+
+    const { user } = await renderApp({ path: "/settings/account" });
+
+    await user.clear(await screen.findByLabelText("Name"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Enter a name.")).toBeInTheDocument();
+    expect(wrote).toBe(false);
+  });
+
+  it("says so when the save fails", async () => {
+    sessionActive();
+    server.use(
+      http.post("/api/auth/update-user", () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const { user } = await renderApp({ path: "/settings/account" });
+
+    const name = await screen.findByLabelText("Name");
+    await user.clear(name);
+    await user.type(name, "Magnus");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Couldn't save that. Try again.")).toBeInTheDocument();
+  });
+});
+
+describe("sign-in methods", () => {
+  it("lists the password when that is the only way in", async () => {
+    sessionActive();
+    linkedProvidersAre(["credential"]);
+
+    await renderApp({ path: "/settings/account" });
+
+    expect(await screen.findByText("Email and password")).toBeInTheDocument();
+    expect(screen.queryByText("Google")).not.toBeInTheDocument();
+  });
+
+  it("lists both when the account has both", async () => {
+    sessionActive();
+    linkedProvidersAre(["credential", "google"]);
+
+    await renderApp({ path: "/settings/account" });
+
+    expect(await screen.findByText("Google")).toBeInTheDocument();
+    expect(screen.getByText("Email and password")).toBeInTheDocument();
+  });
+
+  it("shows only Google for an account that has never had a password", async () => {
+    sessionActive();
+    linkedProvidersAre(["google"]);
+
+    await renderApp({ path: "/settings/account" });
+
+    expect(await screen.findByText("Google")).toBeInTheDocument();
+    expect(screen.queryByText("Email and password")).not.toBeInTheDocument();
+  });
+
+  it("offers no way to unlink one", async () => {
+    sessionActive();
+    linkedProvidersAre(["credential", "google"]);
+
+    await renderApp({ path: "/settings/account" });
+
+    // Deliberate: unlinking the last method locks the person out, and the
+    // guard for that is a decision, not a button this screen can render.
+    expect(await screen.findByText("Google")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /disconnect|unlink|remove/i }),
+    ).toBeNull();
+  });
+
+  it("keeps chess platforms out of this list", async () => {
+    sessionActive();
+    linkedProvidersAre(["credential", "google"]);
+
+    await renderApp({ path: "/settings/account" });
+
+    expect(await screen.findByText("Google")).toBeInTheDocument();
+    // Chess.com and Lichess are where games come from, not ways in.
+    expect(screen.queryByText("Chess.com")).not.toBeInTheDocument();
+    expect(screen.queryByText("Lichess")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Chess.com and Lichess are game sources, not sign-in methods. They live under Import.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("says so when the list cannot be loaded, without hiding the profile", async () => {
+    sessionActive();
+    server.use(
+      http.get("/api/auth/list-accounts", () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+
+    await renderApp({ path: "/settings/account" });
+
+    expect(
+      await screen.findByText("Couldn't load your sign-in methods."),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue(TEST_USER.name)).toBeInTheDocument();
+  });
+});
+
+describe("the avatar", () => {
+  it("falls back to initials for an account with no picture", async () => {
+    sessionActive();
+
+    const { user } = await renderApp({ path: "/" });
+    await user.click(await screen.findByRole("button", { name: "Account" }));
+
+    // "VelaChess User" → first and last initial.
+    const menu = await screen.findByText(TEST_USER.email);
+    expect(
+      within(menu.closest("div")!.parentElement!).getByText("VU"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/settings/account/account-screen.tsx
+++ b/apps/web/src/settings/account/account-screen.tsx
@@ -1,0 +1,237 @@
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { useForm } from "@tanstack/react-form";
+
+import { Button } from "@velachess/ui/components/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@velachess/ui/components/field";
+import { Input } from "@velachess/ui/components/input";
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+} from "@velachess/ui/components/item";
+import { Skeleton } from "@velachess/ui/components/skeleton";
+import { GoogleIcon, KeyRoundIcon } from "@velachess/ui/icons";
+import { PageHeader } from "@velachess/ui/layout/page-header";
+
+import { accountMethodsQuery, PASSWORD_PROVIDER, useRenameSelf } from "./queries.ts";
+import { sessionQuery } from "../../auth/session.ts";
+import { UserAvatar } from "../../auth/user-avatar.tsx";
+import { useQuery } from "../../shared/libs/query/index.ts";
+import { z } from "../../shared/libs/zod.ts";
+
+const ACCOUNT_COPY = {
+  title: msg`Account`,
+  description: msg`Your identity on this instance, and how you sign in to it.`,
+  profile: msg`Profile`,
+  name: msg`Name`,
+  nameHint: msg`How you're shown in the app.`,
+  nameRequired: msg`Enter a name.`,
+  email: msg`Email`,
+  emailFixed: msg`Your email is tied to how you signed up and can't be changed here.`,
+  save: msg`Save`,
+  saving: msg`Saving…`,
+  saved: msg`Saved.`,
+  saveFailed: msg`Couldn't save that. Try again.`,
+  methods: msg`Sign-in methods`,
+  methodsHint: msg`Ways you can get into this account.`,
+  methodsFailed: msg`Couldn't load your sign-in methods.`,
+  google: msg`Google`,
+  googleActive: msg`Connected — you can sign in with Google.`,
+  password: msg`Email and password`,
+  passwordActive: msg`Set — you can sign in with your email and password.`,
+  connections: msg`Chess.com and Lichess are game sources, not sign-in methods. They live under Import.`,
+} as const;
+
+/**
+ * Settings → Account.
+ *
+ * Two questions, in the order people ask them: who am I here, and how do I
+ * get back in. Nothing else — no session list, no delete-account, no
+ * password change — because each of those is a control that has to work,
+ * and Better Auth's `changeEmail`/`forgetPassword` paths want a mail
+ * transport this build does not have. An empty "Danger zone" heading
+ * would only teach people the page is unfinished.
+ *
+ * Sign-in methods are read, never written, for the same reason: unlinking
+ * the only method on an account locks the person out of it, and the guard
+ * for that ("is there another way in?") is a decision, not a checkbox.
+ */
+export function AccountScreen() {
+  const { i18n } = useLingui();
+  const { data: user } = useQuery(sessionQuery);
+  const methods = useQuery(accountMethodsQuery);
+  const rename = useRenameSelf();
+
+  const form = useForm({
+    defaultValues: { name: user?.name ?? "" },
+    onSubmit: async ({ value }) => {
+      // The mutation holds the failure; the submit handler is the end of
+      // the chain, so rethrowing here would land as an unhandled rejection.
+      await rename.mutateAsync(value.name.trim()).catch(() => undefined);
+    },
+  });
+
+  // The route guard resolved the session before this rendered; `user`
+  // being absent means it has just been invalidated and a redirect is
+  // already in flight.
+  if (!user) return null;
+
+  const linked = new Set(methods.data?.map((method) => method.providerId));
+
+  return (
+    <>
+      <PageHeader
+        title={i18n._(ACCOUNT_COPY.title)}
+        description={i18n._(ACCOUNT_COPY.description)}
+      />
+
+      <div className="flex flex-col gap-8 px-6 py-6">
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-medium">{i18n._(ACCOUNT_COPY.profile)}</h2>
+
+          <div className="flex items-center gap-3">
+            <UserAvatar user={user} size="lg" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{user.name}</p>
+              <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+            </div>
+          </div>
+
+          <form
+            className="max-w-sm"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void form.handleSubmit();
+            }}
+          >
+            <FieldGroup>
+              <form.Field
+                name="name"
+                validators={{
+                  onSubmit: z.string().trim().min(1, i18n._(ACCOUNT_COPY.nameRequired)),
+                }}
+              >
+                {(field) => {
+                  const isInvalid =
+                    field.state.meta.isTouched && !field.state.meta.isValid;
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor={field.name}>
+                        {i18n._(ACCOUNT_COPY.name)}
+                      </FieldLabel>
+                      <Input
+                        id={field.name}
+                        name={field.name}
+                        autoComplete="name"
+                        aria-invalid={isInvalid}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => field.handleChange(event.target.value)}
+                        disabled={rename.isPending}
+                      />
+                      <FieldDescription>{i18n._(ACCOUNT_COPY.nameHint)}</FieldDescription>
+                      <FieldError errors={field.state.meta.errors} />
+                    </Field>
+                  );
+                }}
+              </form.Field>
+
+              {/* Shown because people look for it, disabled because
+                  changing it is a verification flow this build cannot
+                  complete. Saying so is the whole point of the field. */}
+              <Field>
+                <FieldLabel htmlFor="account-email">
+                  {i18n._(ACCOUNT_COPY.email)}
+                </FieldLabel>
+                <Input id="account-email" value={user.email} readOnly disabled />
+                <FieldDescription>{i18n._(ACCOUNT_COPY.emailFixed)}</FieldDescription>
+              </Field>
+
+              <Field orientation="horizontal">
+                <Button type="submit" disabled={rename.isPending}>
+                  {rename.isPending
+                    ? i18n._(ACCOUNT_COPY.saving)
+                    : i18n._(ACCOUNT_COPY.save)}
+                </Button>
+                {rename.isSuccess && !rename.isPending && (
+                  <FieldDescription>{i18n._(ACCOUNT_COPY.saved)}</FieldDescription>
+                )}
+                {rename.isError && (
+                  <FieldError>{i18n._(ACCOUNT_COPY.saveFailed)}</FieldError>
+                )}
+              </Field>
+            </FieldGroup>
+          </form>
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <div>
+            <h2 className="text-sm font-medium">{i18n._(ACCOUNT_COPY.methods)}</h2>
+            <p className="text-sm text-muted-foreground">
+              {i18n._(ACCOUNT_COPY.methodsHint)}
+            </p>
+          </div>
+
+          {methods.isPending ? (
+            <Skeleton className="h-24 w-full max-w-md" />
+          ) : methods.isError ? (
+            <p className="text-sm text-muted-foreground">
+              {i18n._(ACCOUNT_COPY.methodsFailed)}
+            </p>
+          ) : (
+            <ItemGroup className="max-w-md rounded-lg border">
+              {linked.has("google") && (
+                <>
+                  <Item>
+                    <ItemMedia>
+                      <GoogleIcon className="size-5" />
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>{i18n._(ACCOUNT_COPY.google)}</ItemTitle>
+                      <ItemDescription>
+                        {i18n._(ACCOUNT_COPY.googleActive)}
+                      </ItemDescription>
+                    </ItemContent>
+                  </Item>
+                  {linked.has(PASSWORD_PROVIDER) && <ItemSeparator />}
+                </>
+              )}
+
+              {linked.has(PASSWORD_PROVIDER) && (
+                <Item>
+                  <ItemMedia>
+                    <KeyRoundIcon className="size-5" />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle>{i18n._(ACCOUNT_COPY.password)}</ItemTitle>
+                    <ItemDescription>
+                      {i18n._(ACCOUNT_COPY.passwordActive)}
+                    </ItemDescription>
+                  </ItemContent>
+                </Item>
+              )}
+            </ItemGroup>
+          )}
+
+          {/* The line the issue asks for in words: a chess account is a
+              source of games, not a way into this one. */}
+          <p className="max-w-md text-xs text-muted-foreground">
+            {i18n._(ACCOUNT_COPY.connections)}
+          </p>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/settings/account/account-screen.tsx
+++ b/apps/web/src/settings/account/account-screen.tsx
@@ -54,18 +54,9 @@ const ACCOUNT_COPY = {
 } as const;
 
 /**
- * Settings → Account.
- *
- * Two questions, in the order people ask them: who am I here, and how do I
- * get back in. Nothing else — no session list, no delete-account, no
- * password change — because each of those is a control that has to work,
- * and Better Auth's `changeEmail`/`forgetPassword` paths want a mail
- * transport this build does not have. An empty "Danger zone" heading
- * would only teach people the page is unfinished.
- *
- * Sign-in methods are read, never written, for the same reason: unlinking
- * the only method on an account locks the person out of it, and the guard
- * for that ("is there another way in?") is a decision, not a checkbox.
+ * Settings → Account: who am I here, and how do I get back in.
+ * Sign-in methods are read-only — unlinking the last one locks the
+ * person out.
  */
 export function AccountScreen() {
   const { i18n } = useLingui();
@@ -76,15 +67,10 @@ export function AccountScreen() {
   const form = useForm({
     defaultValues: { name: user?.name ?? "" },
     onSubmit: async ({ value }) => {
-      // The mutation holds the failure; the submit handler is the end of
-      // the chain, so rethrowing here would land as an unhandled rejection.
       await rename.mutateAsync(value.name.trim()).catch(() => undefined);
     },
   });
 
-  // The route guard resolved the session before this rendered; `user`
-  // being absent means it has just been invalidated and a redirect is
-  // already in flight.
   if (!user) return null;
 
   const linked = new Set(methods.data?.map((method) => method.providerId));
@@ -148,9 +134,6 @@ export function AccountScreen() {
                 }}
               </form.Field>
 
-              {/* Shown because people look for it, disabled because
-                  changing it is a verification flow this build cannot
-                  complete. Saying so is the whole point of the field. */}
               <Field>
                 <FieldLabel htmlFor="account-email">
                   {i18n._(ACCOUNT_COPY.email)}
@@ -225,8 +208,6 @@ export function AccountScreen() {
             </ItemGroup>
           )}
 
-          {/* The line the issue asks for in words: a chess account is a
-              source of games, not a way into this one. */}
           <p className="max-w-md text-xs text-muted-foreground">
             {i18n._(ACCOUNT_COPY.connections)}
           </p>

--- a/apps/web/src/settings/account/account-screen.tsx
+++ b/apps/web/src/settings/account/account-screen.tsx
@@ -37,6 +37,7 @@ const ACCOUNT_COPY = {
   name: msg`Name`,
   nameHint: msg`How you're shown in the app.`,
   nameRequired: msg`Enter a name.`,
+  nameTooLong: msg`Keep it under 100 characters.`,
   email: msg`Email`,
   emailFixed: msg`Your email is tied to how you signed up and can't be changed here.`,
   save: msg`Save`,
@@ -105,7 +106,11 @@ export function AccountScreen() {
               <form.Field
                 name="name"
                 validators={{
-                  onSubmit: z.string().trim().min(1, i18n._(ACCOUNT_COPY.nameRequired)),
+                  onSubmit: z
+                    .string()
+                    .trim()
+                    .min(1, i18n._(ACCOUNT_COPY.nameRequired))
+                    .max(100, i18n._(ACCOUNT_COPY.nameTooLong)),
                 }}
               >
                 {(field) => {
@@ -124,7 +129,12 @@ export function AccountScreen() {
                         aria-invalid={isInvalid}
                         value={field.state.value}
                         onBlur={field.handleBlur}
-                        onChange={(event) => field.handleChange(event.target.value)}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value);
+                          // Otherwise "Saved." (or a stale error) outlives
+                          // the edit it no longer describes.
+                          rename.reset();
+                        }}
                         disabled={rename.isPending}
                       />
                       <FieldDescription>{i18n._(ACCOUNT_COPY.nameHint)}</FieldDescription>

--- a/apps/web/src/settings/account/queries.ts
+++ b/apps/web/src/settings/account/queries.ts
@@ -1,9 +1,4 @@
-/**
- * Account reads and writes, all of them Better Auth's own endpoints.
- *
- * Nothing here talks to our API: identity is Better Auth's to own, and a
- * second write path to the same rows is how the two get to disagree.
- */
+/** Account reads/writes — Better Auth's own endpoints, never our API. */
 
 import { authClient } from "../../auth/client.ts";
 import { fetchSession, sessionQueryKey } from "../../auth/session.ts";
@@ -13,14 +8,7 @@ import {
   useQueryClient,
 } from "../../shared/libs/query/index.ts";
 
-/**
- * A way of signing in that this account actually has.
- *
- * `credential` is Better Auth's provider id for email+password; every other
- * id is a social provider. The distinction matters to the screen: the
- * password row talks about a password, the Google row about an account
- * elsewhere.
- */
+/** Better Auth's provider id for email+password. */
 export const PASSWORD_PROVIDER = "credential";
 
 export interface SignInMethod {
@@ -41,14 +29,8 @@ export const accountMethodsQuery = queryOptions({
   },
 });
 
-/**
- * Renames the person, nothing else.
- *
- * Email is deliberately not writable here: changing it is a verification
- * flow (Better Auth's `changeEmail` sends to the current address first),
- * and this build has no mail transport. A field that looks editable and
- * silently is not would be worse than a read-only one.
- */
+/** Renames only. Email needs `changeEmail`'s verification flow, and
+ * this build has no mail transport. */
 export function useRenameSelf() {
   const queryClient = useQueryClient();
 
@@ -58,9 +40,7 @@ export function useRenameSelf() {
       if (error) throw new Error(`could not update profile (${error.status})`);
     },
     onSuccess: async () => {
-      // The session query is where the rest of the app reads the name
-      // from — the shell's user menu included — so it is refreshed from
-      // the server rather than patched locally.
+      // The shell reads the name from the session query — refresh it.
       queryClient.setQueryData(sessionQueryKey, await fetchSession());
     },
   });

--- a/apps/web/src/settings/account/queries.ts
+++ b/apps/web/src/settings/account/queries.ts
@@ -1,7 +1,7 @@
 /** Account reads/writes — Better Auth's own endpoints, never our API. */
 
 import { authClient } from "../../auth/client.ts";
-import { fetchSession, sessionQueryKey } from "../../auth/session.ts";
+import { sessionQueryKey } from "../../auth/session.ts";
 import {
   queryOptions,
   useMutation,
@@ -39,9 +39,11 @@ export function useRenameSelf() {
       const { error } = await authClient.updateUser({ name });
       if (error) throw new Error(`could not update profile (${error.status})`);
     },
-    onSuccess: async () => {
+    onSuccess: () => {
       // The shell reads the name from the session query — refresh it.
-      queryClient.setQueryData(sessionQueryKey, await fetchSession());
+      // Invalidate rather than refetch-then-set: a network blip here must
+      // not turn a rename that already succeeded into a shown failure.
+      return queryClient.invalidateQueries({ queryKey: sessionQueryKey });
     },
   });
 }

--- a/apps/web/src/settings/account/queries.ts
+++ b/apps/web/src/settings/account/queries.ts
@@ -1,0 +1,67 @@
+/**
+ * Account reads and writes, all of them Better Auth's own endpoints.
+ *
+ * Nothing here talks to our API: identity is Better Auth's to own, and a
+ * second write path to the same rows is how the two get to disagree.
+ */
+
+import { authClient } from "../../auth/client.ts";
+import { fetchSession, sessionQueryKey } from "../../auth/session.ts";
+import {
+  queryOptions,
+  useMutation,
+  useQueryClient,
+} from "../../shared/libs/query/index.ts";
+
+/**
+ * A way of signing in that this account actually has.
+ *
+ * `credential` is Better Auth's provider id for email+password; every other
+ * id is a social provider. The distinction matters to the screen: the
+ * password row talks about a password, the Google row about an account
+ * elsewhere.
+ */
+export const PASSWORD_PROVIDER = "credential";
+
+export interface SignInMethod {
+  providerId: string;
+  createdAt: string;
+}
+
+export const accountMethodsQuery = queryOptions({
+  queryKey: ["auth", "accounts"] as const,
+  queryFn: async (): Promise<SignInMethod[]> => {
+    const { data, error } = await authClient.listAccounts();
+    if (error) throw new Error(`could not list sign-in methods (${error.status})`);
+
+    return (data ?? []).map((account) => ({
+      providerId: account.providerId,
+      createdAt: String(account.createdAt),
+    }));
+  },
+});
+
+/**
+ * Renames the person, nothing else.
+ *
+ * Email is deliberately not writable here: changing it is a verification
+ * flow (Better Auth's `changeEmail` sends to the current address first),
+ * and this build has no mail transport. A field that looks editable and
+ * silently is not would be worse than a read-only one.
+ */
+export function useRenameSelf() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (name: string) => {
+      const { error } = await authClient.updateUser({ name });
+      if (error) throw new Error(`could not update profile (${error.status})`);
+    },
+    onSuccess: async () => {
+      // The session query is where the rest of the app reads the name
+      // from — the shell's user menu included — so it is refreshed from
+      // the server rather than patched locally.
+      queryClient.setQueryData(sessionQueryKey, await fetchSession());
+    },
+  });
+}

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -1,7 +1,12 @@
 import type { AppType } from "@velachess/server";
 
 import { DetailedError, hc, parseResponse as parseHonoResponse } from "../libs/hono.ts";
-import { CancelledError, NetworkError, UnauthorizedError } from "./errors.ts";
+import {
+  CancelledError,
+  NetworkError,
+  RateLimitedError,
+  UnauthorizedError,
+} from "./errors.ts";
 
 export { DetailedError } from "../libs/hono.ts";
 export type { InferResponseType } from "../libs/hono.ts";
@@ -26,12 +31,26 @@ const apiFetch: typeof fetch = async (input, init) => {
 
 export const api = hc<AppType>(apiBaseUrl, { fetch: apiFetch });
 
+/**
+ * The wait a 429 body carries, when it carries one. Both throttles on the
+ * server — the rate-limit middleware and the sync cooldown — write
+ * `retryAfterSeconds` into the body, precisely because this client can
+ * only see a rejection's body, never its `Retry-After` header.
+ */
+function retryAfterOf(error: DetailedError): number | null {
+  const data = error.detail?.data as { retryAfterSeconds?: unknown } | undefined;
+  return typeof data?.retryAfterSeconds === "number" ? data.retryAfterSeconds : null;
+}
+
 export const parseResponse: typeof parseHonoResponse = async (...args) => {
   try {
     return await parseHonoResponse(...args);
   } catch (error) {
     if (error instanceof DetailedError && error.statusCode === 401) {
       throw new UnauthorizedError("Unauthorized", { cause: error });
+    }
+    if (error instanceof DetailedError && error.statusCode === 429) {
+      throw new RateLimitedError(retryAfterOf(error), { cause: error });
     }
     throw error;
   }

--- a/apps/web/src/shared/api/errors.ts
+++ b/apps/web/src/shared/api/errors.ts
@@ -19,6 +19,26 @@ export class InvalidResponseError extends ApiError {}
 
 export class UnauthorizedError extends ApiError {}
 
+/**
+ * A 429 — the server refused because a budget ran out; the request would
+ * have worked otherwise.
+ *
+ * Its own class because it wants the opposite reaction from every other
+ * failure: "something broke" invites an immediate retry, which is exactly
+ * what the refusal asked not to get. `retryAfterSeconds` comes from the
+ * response BODY — the server writes it there because this client cannot
+ * read a rejection's headers — and is `null` when a 429 arrives without
+ * one.
+ */
+export class RateLimitedError extends ApiError {
+  readonly retryAfterSeconds: number | null;
+
+  constructor(retryAfterSeconds: number | null, options: ApiErrorOptions = {}) {
+    super("Rate limited", options);
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
 export function isNetworkError(error: unknown) {
   return error instanceof NetworkError;
 }
@@ -29,6 +49,10 @@ export function isCancelledError(error: unknown) {
 
 export function isUnauthorizedError(error: unknown) {
   return error instanceof UnauthorizedError;
+}
+
+export function isRateLimitedError(error: unknown): error is RateLimitedError {
+  return error instanceof RateLimitedError;
 }
 
 export function isInvalidResponseError(error: unknown) {

--- a/apps/web/src/test/handlers/auth.ts
+++ b/apps/web/src/test/handlers/auth.ts
@@ -8,6 +8,9 @@ export interface TestSessionUser {
   id: string;
   email: string;
   name: string;
+  /** Absent by default on purpose: a password account has no picture, so
+   * the avatar's initials fallback is the path most of the suite runs. */
+  image?: string | null;
 }
 
 export const TEST_USER: TestSessionUser = {
@@ -15,6 +18,28 @@ export const TEST_USER: TestSessionUser = {
   email: "user@velachess.local",
   name: "VelaChess User",
 };
+
+/**
+ * What `GET /api/config` reports. Google is off by default for the same
+ * reason the real server defaults it off — an instance without
+ * credentials does not offer it — so a test that wants the button says
+ * so, and every other test proves its absence.
+ */
+let signInMethods = { password: true, google: false };
+
+export function signInMethodsAre(methods: {
+  password?: boolean;
+  google?: boolean;
+}): void {
+  signInMethods = { ...signInMethods, ...methods };
+}
+
+/** Providers this account can sign in with, as `/list-accounts` reports. */
+let linkedProviders: string[] = ["credential"];
+
+export function linkedProvidersAre(providers: string[]): void {
+  linkedProviders = providers;
+}
 
 export const TEST_PASSWORD = "dev-password";
 
@@ -43,6 +68,8 @@ export function sessionUnavailable(): void {
 
 export function resetAuthScenario(): void {
   scenario = { kind: "signed-in", user: TEST_USER };
+  signInMethods = { password: true, google: false };
+  linkedProviders = ["credential"];
 }
 
 function sessionBody(user: TestSessionUser) {
@@ -56,7 +83,7 @@ function sessionBody(user: TestSessionUser) {
     user: {
       ...user,
       emailVerified: false,
-      image: null,
+      image: user.image ?? null,
       createdAt: new Date(0).toISOString(),
       updatedAt: new Date(0).toISOString(),
     },
@@ -64,6 +91,10 @@ function sessionBody(user: TestSessionUser) {
 }
 
 export const authHandlers = [
+  // Not under BASE: this one is our API, not Better Auth's — the sign-in
+  // screen asks it what to render before there is anyone to authenticate.
+  http.get("/api/config", () => HttpResponse.json({ signInMethods })),
+
   http.get(`${BASE}/get-session`, () => {
     if (scenario.kind === "unavailable") {
       return HttpResponse.json({ message: "boom" }, { status: 500 });
@@ -96,6 +127,39 @@ export const authHandlers = [
   http.post(`${BASE}/sign-out`, () => {
     sessionInactive();
     return HttpResponse.json({ success: true });
+  }),
+
+  // What Better Auth answers a social sign-in with: the provider's
+  // authorization URL, for the client to send the browser to. jsdom does
+  // not navigate, which is exactly why the assertion is on the request
+  // rather than on a redirect.
+  http.post(`${BASE}/sign-in/social`, () =>
+    HttpResponse.json({
+      url: "https://accounts.google.com/o/oauth2/v2/auth?client_id=test",
+      redirect: true,
+    }),
+  ),
+
+  http.get(`${BASE}/list-accounts`, () =>
+    HttpResponse.json(
+      linkedProviders.map((providerId, index) => ({
+        id: `account-${index}`,
+        providerId,
+        accountId: `${providerId}-account`,
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      })),
+    ),
+  ),
+
+  http.post(`${BASE}/update-user`, async ({ request }) => {
+    const body = (await request.json()) as { name?: string };
+    if (scenario.kind === "signed-in" && body.name) {
+      // The session is where the app reads the name back from, so the
+      // fake server has to actually change it or the test proves nothing.
+      scenario = { kind: "signed-in", user: { ...scenario.user, name: body.name } };
+    }
+    return HttpResponse.json({ status: true });
   }),
 
   // Closed on the real server, closed here too — the frontend must never

--- a/apps/web/src/test/routes.tsx
+++ b/apps/web/src/test/routes.tsx
@@ -13,6 +13,7 @@ import { GameAnalysis } from "../games/open-game/game-analysis.tsx";
 import { GamesList } from "../games/games-list.tsx";
 import { ImportGames } from "../games/import/import-games.tsx";
 import { SignInScreen } from "../auth/sign-in/sign-in-screen.tsx";
+import { AccountScreen } from "../settings/account/account-screen.tsx";
 import { resolveSession } from "../auth/session.ts";
 import { gamesSearchSchema } from "../games/list/filters.ts";
 import { drillSearchSchema } from "../drill/queries.ts";
@@ -150,6 +151,31 @@ const importRoute = createRoute({
   component: ImportGames,
 });
 
+// Nested for real, like /games and /repertoire: the account screen is
+// reached from the shell's user menu, so the link has to resolve against
+// the same tree the menu renders inside.
+const settingsRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: "/settings",
+  staticData: { crumb: msg`Settings` },
+  component: Outlet,
+});
+
+const settingsIndexRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: "/",
+  beforeLoad: () => {
+    throw redirect({ to: "/settings/account", replace: true });
+  },
+});
+
+const accountRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: "/account",
+  staticData: { crumb: msg`Account` },
+  component: AccountScreen,
+});
+
 // Public, and the mirror image of the guard above: already signed in
 // means there is nothing to do here.
 const loginRoute = createRoute({
@@ -157,6 +183,9 @@ const loginRoute = createRoute({
   path: "/login",
   validateSearch: (search: Record<string, unknown>) => ({
     redirect: typeof search["redirect"] === "string" ? search["redirect"] : undefined,
+    // Mirrors the real route: an OAuth failure comes back on the address
+    // bar, and the screen renders a message rather than the raw code.
+    error: typeof search["error"] === "string" ? search["error"] : undefined,
   }),
   beforeLoad: async ({ context, search }) => {
     const session = await resolveSession(context.queryClient);
@@ -168,8 +197,13 @@ const loginRoute = createRoute({
 });
 
 function TestLoginRoute() {
-  const { redirect: destination } = loginRoute.useSearch();
-  return <SignInScreen {...(destination ? { redirect: destination } : {})} />;
+  const { redirect: destination, error } = loginRoute.useSearch();
+  return (
+    <SignInScreen
+      {...(destination ? { redirect: destination } : {})}
+      {...(error ? { oauthError: error } : {})}
+    />
+  );
 }
 
 let crashRouteThrows = false;
@@ -206,6 +240,7 @@ export const testRouteTree = rootRoute.addChildren([
     drillRoute,
     insightsRoute,
     importRoute,
+    settingsRoute.addChildren([settingsIndexRoute, accountRoute]),
   ]),
   loginRoute,
   crashRoute,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -33,6 +33,16 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },
+      // The OAuth return leg — the one request the browser does not choose
+      // the URL for. Better Auth builds its redirect_uri from its own
+      // baseURL and basePath, so Google sends the user to
+      // `<origin>/auth/callback/google`, with no /api prefix to rewrite
+      // away. Forwarded verbatim, since the API already mounts auth at
+      // /auth/*. A production reverse proxy needs the same location.
+      "/auth": {
+        target: API_TARGET,
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -25,23 +25,15 @@ export default defineConfig({
     // a container (VS Code's Dev Container port forwarding needs a real
     // listening interface, not the container's internal loopback).
     host: true,
-    // The API has no CORS middleware by design — the browser only ever talks
-    // to this origin, and /api is rewritten onto the API in dev.
+    // The browser only ever talks to this origin; /api is rewritten onto
+    // the API in dev. The Google OAuth return leg lands here too — the
+    // provider is configured with an explicit redirectURI under /api
+    // (libs/infra/auth/auth.ts), so it needs no second proxy rule.
     proxy: {
       "/api": {
         target: API_TARGET,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
-      },
-      // The OAuth return leg — the one request the browser does not choose
-      // the URL for. Better Auth builds its redirect_uri from its own
-      // baseURL and basePath, so Google sends the user to
-      // `<origin>/auth/callback/google`, with no /api prefix to rewrite
-      // away. Forwarded verbatim, since the API already mounts auth at
-      // /auth/*. A production reverse proxy needs the same location.
-      "/auth": {
-        target: API_TARGET,
-        changeOrigin: true,
       },
     },
   },

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,6 +54,13 @@ services:
       # silently-defaulted base URL is refused at boot anyway.
       VELACHESS_BASE_URL: ${VELACHESS_BASE_URL:?set the public URL, e.g. http://localhost:3000}
       VELACHESS_TRUSTED_ORIGINS: ${VELACHESS_TRUSTED_ORIGINS:-}
+      # Google sign-in: both or neither (libs/infra/auth/env.ts refuses to
+      # boot with only one set).
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      # Reverse proxies in front of this container, if any — see
+      # docs/how-to/self-host.md#behind-a-reverse-proxy.
+      VELACHESS_TRUSTED_PROXIES: ${VELACHESS_TRUSTED_PROXIES:-}
       # TEMPORARY: first boot creates this user into an empty user table;
       # later boots skip. Deliberately optional — the lifecycle ends with
       # removing both from .env after first login (docs/how-to/self-host.md,

--- a/docs/explanation/modules/analysis.md
+++ b/docs/explanation/modules/analysis.md
@@ -58,7 +58,7 @@ pins it to Lichess's public implementation, same inputs, same expected
 outputs:
 
 | What                                                       | Reference source                                                                                                                            |
-| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | Win% formula + cp ceiling + mate mapping                   | `scalachess core/src/main/scala/eval.scala` (`WinPercent.winningChances`, `fromCentiPawns`, `fromMate`); prose at lichess.org/page/accuracy |
 | Judgment thresholds (.1/.2/.3 win-chance drop)             | `lila modules/tree/src/main/Advice.scala` (`CpAdvice.winningChanceJudgements`)                                                              |
 | Move accuracy curve (exact constants, +1 bonus)            | `lila modules/analyze/src/main/AccuracyPercent.scala` (`fromWinPercents`)                                                                   |

--- a/docs/explanation/modules/db.md
+++ b/docs/explanation/modules/db.md
@@ -154,20 +154,25 @@ orchestration layer that reads a chapter's PGN and feeds
 
 ## Dedup
 
-Two constraints, not one: a partial unique index on `(source,
-external_id) WHERE external_id IS NOT NULL` catches every Chess.com/Lichess
-re-sync for free, no hashing. A table-level unique constraint on
-`(account_id, movetext_hash)` with `NULLS NOT DISTINCT` catches a pasted
-PGN re-pasted with no linked account — Postgres treats `NULL` as distinct
-from itself by default, which would silently defeat this exact case
-without that clause. `saveGames` inserts with a bare `onConflictDoNothing()`
-(no target), which lets one statement satisfy both constraints at once,
-and reads the actual inserted count off what Postgres returns rather than
-pre-selecting to check.
+Both constraints are scoped to the tracked account, not global: a
+partial unique index on `(account_id, source, external_id) WHERE
+external_id IS NOT NULL` catches every Chess.com/Lichess re-sync for
+free, no hashing, within that account. A table-level unique constraint
+on `(account_id, movetext_hash)` with `NULLS NOT DISTINCT` catches a
+pasted PGN re-pasted with no linked account — Postgres treats `NULL` as
+distinct from itself by default, which would silently defeat this exact
+case without that clause. `saveGames` inserts with a bare
+`onConflictDoNothing()` (no target), which lets one statement satisfy
+both constraints at once, and reads the actual inserted count off what
+Postgres returns rather than pre-selecting to check.
 
-Known limitation, not fixed: the source/external_id index is global, so if
-two different tracked accounts both play the same game, only the first
-import sticks. One game = one row is the honest model for now.
+Each tracked account owns a complete, independent copy of whatever it
+imports. Two accounts (any two users, or the same user twice) tracking
+the same real chess.com/Lichess handle each get their own full history
+— dedup only ever happens within one account, never across two. This
+duplicates storage when that happens, deliberately: simple, correct
+isolation over global storage dedup. A `game_accounts` join table is
+the upgrade path if duplication ever becomes a measured problem.
 
 ## Client
 

--- a/docs/explanation/modules/drill.md
+++ b/docs/explanation/modules/drill.md
@@ -3,7 +3,7 @@
 **[DRILL] — turns mistakes, deviations and prepared lines into recallable
 exercises.** Three slices own the loop: `seed-exercises` (triage and
 generation), `get-next-drill` (the queue), `submit-answer` (grading and the
-FSRS handoff). Deciding *when* to review is the scheduler's job, not this
+FSRS handoff). Deciding _when_ to review is the scheduler's job, not this
 package's. Exact rules, constants and shapes live in
 `docs/reference/drills.md`; this document is the reasoning.
 
@@ -25,7 +25,7 @@ flowchart TD
 An exercise can be born three ways, and the origins deliberately ask
 different questions:
 
-- **`repertoire-deviation`** — did you play what you *decided*? Your own move
+- **`repertoire-deviation`** — did you play what you _decided_? Your own move
   left your book and the book had an answer to recall. Nothing about
   severity: forgetting your line for a perfectly sound alternative costs zero
   evaluation, so the engine is permanently silent about it — and that is
@@ -35,7 +35,7 @@ different questions:
   repertoire existed, so the requirement was removed. Volume needs no budget
   here: `deviations_game_repertoire` guarantees at most one deviation per
   game per repertoire.
-- **`engine-blunder`** — did you play *well*? Every graded ply of your side is
+- **`engine-blunder`** — did you play _well_? Every graded ply of your side is
   a candidate. Volume does not come from a severity floor — measured on real
   games, blunder is the most common category, so a fixed floor either starves
   strong players or drowns beginners. Instead candidates are ranked by
@@ -60,7 +60,7 @@ origins, merges into one exercise with one provenance row per origin in
 `exercise_sources`, enforced by partial unique indexes rather than caller
 discipline.
 
-When origins collide, the preparation wins the *answer*: a repertoire seed
+When origins collide, the preparation wins the _answer_: a repertoire seed
 refreshes `expected_sans`, an engine seed only adds its provenance. The
 engine is a strong opinion about the position; your book is a decision about
 what you intend to play, and drilling should not quietly redirect you away

--- a/docs/how-to/self-host.md
+++ b/docs/how-to/self-host.md
@@ -129,17 +129,9 @@ them again.
 
 ## Behind a reverse proxy
 
-Two things need saying to the proxy, and both are quiet when wrong.
-
-**Route `/auth/*` to the API, not only `/api/*`.** The browser reaches
-every auth call under `/api/auth/…`, which the proxy rewrites onto the
-API — except one. Better Auth builds its OAuth `redirect_uri` from its
-own base URL, so Google returns the user to
-`<VELACHESS_BASE_URL>/auth/callback/google`, with no `/api` prefix to
-rewrite away. Without a second location for `/auth/`, that return leg
-lands on the SPA and 404s, and the symptom reads as "Google sign-in is
-broken" rather than as a missing proxy rule. The dev proxy already does
-this (`apps/web/vite.config.ts`); production needs the same.
+Every auth call, including the Google OAuth return leg, reaches the API
+under `/api/…` — one location (`/api/*`) is enough; there is no second
+path to route.
 
 **Set `VELACHESS_TRUSTED_PROXIES`** to the proxy's address, or to the
 CIDR range it sits in (comma-separated for several). Better Auth keys
@@ -157,7 +149,7 @@ fails at the redirect. Leave both unset and the provider is simply not
 offered.
 
 In the Google Cloud console, the authorized redirect URI is
-`<VELACHESS_BASE_URL>/auth/callback/google` — see the proxy note above.
+`<VELACHESS_BASE_URL>/api/auth/callback/google`.
 
 This is also what opens public sign-up without an SMTP dependency:
 `POST /auth/sign-up/email` stays closed (`disableSignUp` governs the

--- a/docs/how-to/self-host.md
+++ b/docs/how-to/self-host.md
@@ -127,14 +127,52 @@ reason: users-exist` (or `not-configured` once step 6 is done) — both
 mean the same thing: your users are yours, and startup will never touch
 them again.
 
+## Behind a reverse proxy
+
+Two things need saying to the proxy, and both are quiet when wrong.
+
+**Route `/auth/*` to the API, not only `/api/*`.** The browser reaches
+every auth call under `/api/auth/…`, which the proxy rewrites onto the
+API — except one. Better Auth builds its OAuth `redirect_uri` from its
+own base URL, so Google returns the user to
+`<VELACHESS_BASE_URL>/auth/callback/google`, with no `/api` prefix to
+rewrite away. Without a second location for `/auth/`, that return leg
+lands on the SPA and 404s, and the symptom reads as "Google sign-in is
+broken" rather than as a missing proxy rule. The dev proxy already does
+this (`apps/web/vite.config.ts`); production needs the same.
+
+**Set `VELACHESS_TRUSTED_PROXIES`** to the proxy's address, or to the
+CIDR range it sits in (comma-separated for several). Better Auth keys
+its sign-in throttling by client IP, and behind a proxy every request
+arrives from the proxy's address. It refuses to trust a forwarded chain
+it cannot attribute, and falls back to a **single shared bucket for the
+whole site** — three failed sign-ins by anyone lock out everyone, with
+nothing but one log line to say so.
+
+## Sign-in with Google (optional)
+
+Set both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. Setting one
+without the other refuses to boot, rather than shipping a button that
+fails at the redirect. Leave both unset and the provider is simply not
+offered.
+
+In the Google Cloud console, the authorized redirect URI is
+`<VELACHESS_BASE_URL>/auth/callback/google` — see the proxy note above.
+
+This is also what opens public sign-up without an SMTP dependency:
+`POST /auth/sign-up/email` stays closed (`disableSignUp` governs the
+password path only), while social sign-in creates the account on first
+use.
+
 ## What refuses to boot, and why
 
-| Condition                                             | Behavior                                                                                                        |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `VELACHESS_AUTH_SECRET` missing or under 32 chars     | Startup fails; the error names the variable and how to generate one. The value is never printed.                |
-| Production with the `.env.example` placeholder secret | Startup fails — a copied example file is indistinguishable from no secret.                                      |
-| Production without `VELACHESS_BASE_URL`               | Startup fails — cookies and trusted origins for a defaulted localhost would belong to a host nobody is on.      |
-| Production with an `http://` base URL                 | Boots, with a loud warning: put TLS in front. `Secure` cookies follow the actual transport and are never faked. |
+| Condition                                                            | Behavior                                                                                                        |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `VELACHESS_AUTH_SECRET` missing or under 32 chars                    | Startup fails; the error names the variable and how to generate one. The value is never printed.                |
+| Production with the `.env.example` placeholder secret                | Startup fails — a copied example file is indistinguishable from no secret.                                      |
+| Production without `VELACHESS_BASE_URL`                              | Startup fails — cookies and trusted origins for a defaulted localhost would belong to a host nobody is on.      |
+| One of `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` without the other | Startup fails — half a provider is a button that fails at the redirect instead of at boot.                      |
+| Production with an `http://` base URL                                | Boots, with a loud warning: put TLS in front. `Secure` cookies follow the actual transport and are never faked. |
 
 All of these rules live in `libs/infra/auth/env.ts` with unit tests
 beside them.

--- a/docs/reference/analysis.md
+++ b/docs/reference/analysis.md
@@ -6,16 +6,16 @@ rules, and persisted shapes. The reasoning behind these choices lives in
 
 ## Engine configuration (production)
 
-| Setting          | Value                                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| Setting          | Value                                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Binary           | `ENGINE_CMD` env var if set; otherwise `stockfish` npm `^18.0.8` (`stockfish-18-lite-single.js`, single-threaded WASM) run as a Node child process — `apps/worker/src/main.ts` |
-| Depth            | **12** — `deps.depth ?? 12` in `process-analysis.ts`; the worker passes no depth, so `analyzeGame`'s own default of 14 is never used in production |
-| UCI options      | None set. No Threads, no Hash, no MultiPV — `EngineSession.setOption` has no production caller. Only `multipv === 1` info lines are read |
-| Search           | `go depth <N>` once per mainline position                                                                     |
-| Watchdog         | `min(30000, max(5000, 3000 + depth·400))` ms per search (7800 ms at depth 12); on timeout `stop` + 2 s grace  |
-| Failure policy   | One whole-game retry on a fresh session; a second failure throws                                              |
-| Handshake        | `EngineSession.init` fails after 10 s without `uciok`/`readyok`                                               |
-| `engine_version` | Stored as the literal `"stockfish"` (`deps.engineVersion ?? "stockfish"`; nothing passes a value)             |
+| Depth            | **12** — `deps.depth ?? 12` in `process-analysis.ts`; the worker passes no depth, so `analyzeGame`'s own default of 14 is never used in production                             |
+| UCI options      | None set. No Threads, no Hash, no MultiPV — `EngineSession.setOption` has no production caller. Only `multipv === 1` info lines are read                                       |
+| Search           | `go depth <N>` once per mainline position                                                                                                                                      |
+| Watchdog         | `min(30000, max(5000, 3000 + depth·400))` ms per search (7800 ms at depth 12); on timeout `stop` + 2 s grace                                                                   |
+| Failure policy   | One whole-game retry on a fresh session; a second failure throws                                                                                                               |
+| Handshake        | `EngineSession.init` fails after 10 s without `uciok`/`readyok`                                                                                                                |
+| `engine_version` | Stored as the literal `"stockfish"` (`deps.engineVersion ?? "stockfish"`; nothing passes a value)                                                                              |
 
 Analysis has one trigger: `POST /games/:id/analyze` enqueues (pg-boss); the
 worker executes. Execution ownership is the session advisory lock

--- a/docs/reference/drills.md
+++ b/docs/reference/drills.md
@@ -16,11 +16,11 @@ its provenance row and does not change the expected answers.
 
 ## Origins (`drill_origin` enum)
 
-| Origin                 | Source                          | Rule                                                                    | Required columns on `exercise_sources` |
-| ---------------------- | ------------------------------- | ----------------------------------------------------------------------- | -------------------------------------- |
-| `repertoire-deviation` | `deviations` rows               | `type === "deviation"` and non-empty `expected_sans`. **No severity or analysis requirement** | `deviation_id`                         |
-| `engine-blunder`       | `game_analyses` jsonb plies     | user's side only; category floor `inaccuracy` (`severeEnough`); ranked by `winChanceLoss` desc, ply asc; **budget 5 per game** (`selectDrillCandidates`); engine's UCI best converted to SAN in the ply's FEN, illegal → no exercise | `game_id` + `ply`                      |
-| `repertoire-line`      | chapter decision positions      | every decision position, seeded when the chapter lands                   | `chapter_id`                           |
+| Origin                 | Source                      | Rule                                                                                                                                                                                                                                 | Required columns on `exercise_sources` |
+| ---------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| `repertoire-deviation` | `deviations` rows           | `type === "deviation"` and non-empty `expected_sans`. **No severity or analysis requirement**                                                                                                                                        | `deviation_id`                         |
+| `engine-blunder`       | `game_analyses` jsonb plies | user's side only; category floor `inaccuracy` (`severeEnough`); ranked by `winChanceLoss` desc, ply asc; **budget 5 per game** (`selectDrillCandidates`); engine's UCI best converted to SAN in the ply's FEN, illegal → no exercise | `game_id` + `ply`                      |
+| `repertoire-line`      | chapter decision positions  | every decision position, seeded when the chapter lands                                                                                                                                                                               | `chapter_id`                           |
 
 Per-origin idempotency comes from partial unique indexes; the
 `exercise_sources_origin_shape` CHECK ties each origin to exactly its columns.

--- a/docs/reference/opening-data.md
+++ b/docs/reference/opening-data.md
@@ -11,11 +11,11 @@ Written once at import by `normalizeGame`
 (`libs/infra/platforms/normalize.ts`), straight from PGN headers, never
 recomputed:
 
-| Column               | Source header | chess.com  | Lichess |
-| -------------------- | ------------- | ---------- | ------- |
-| `games.opening_eco`  | `ECO`         | sent       | sent    |
-| `games.opening_name` | `Opening`     | never sent (always null) | sent ("Family: Variation") |
-| `games.opening_url`  | `ECOUrl`      | sent (name lives in the slug) | not sent |
+| Column               | Source header | chess.com                     | Lichess                    |
+| -------------------- | ------------- | ----------------------------- | -------------------------- |
+| `games.opening_eco`  | `ECO`         | sent                          | sent                       |
+| `games.opening_name` | `Opening`     | never sent (always null)      | sent ("Family: Variation") |
+| `games.opening_url`  | `ECOUrl`      | sent (name lives in the slug) | not sent                   |
 
 No validation or lookup happens on any of the three.
 
@@ -38,11 +38,11 @@ insight bucket "Closed Sicilian Defense".
 
 ## Consumers
 
-| Consumer                       | What it reads                                                       |
-| ------------------------------ | ------------------------------------------------------------------- |
-| Game report and games list UI  | raw columns (`game.openingName`, `game.openingEco`); chess.com games render the unknown-opening copy because `opening_name` is null |
-| Insights (`opening-weakness`)  | `openingFamily(...)` derived at read time; floors: 5 decided games per opening, 20 baseline games, 0.10 win-rate delta |
-| Repertoire extraction          | `openingNameFrom(...)` for chapter names (dominant among supporting games, fallback `Line N`) |
+| Consumer                      | What it reads                                                                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Game report and games list UI | raw columns (`game.openingName`, `game.openingEco`); chess.com games render the unknown-opening copy because `opening_name` is null |
+| Insights (`opening-weakness`) | `openingFamily(...)` derived at read time; floors: 5 decided games per opening, 20 baseline games, 0.10 win-rate delta              |
+| Repertoire extraction         | `openingNameFrom(...)` for chapter names (dominant among supporting games, fallback `Line N`)                                       |
 
 ## Interaction with analysis
 

--- a/libs/application/auth/bootstrap-user/bootstrap-user.ts
+++ b/libs/application/auth/bootstrap-user/bootstrap-user.ts
@@ -4,7 +4,7 @@
  * Called a "user", not "admin": the product has no roles/RBAC to justify the word.
  */
 
-import { count } from "drizzle-orm";
+import { count, eq } from "drizzle-orm";
 
 import type { Database, ExecutionLock } from "@velachess/db";
 import { schema } from "@velachess/db";
@@ -61,6 +61,15 @@ export async function bootstrapUser(
         password: credentials.password,
       },
     });
+
+    // signUpEmail hard-codes emailVerified: false, not overridable via the
+    // body. The operator running this already controls the box the email
+    // sits on, so verification proves nothing — and left false, this
+    // account fails Google's account-linking check on first use.
+    await db
+      .update(schema.users)
+      .set({ emailVerified: true })
+      .where(eq(schema.users.id, created.user.id));
 
     return { status: "created", userId: created.user.id };
   } finally {

--- a/libs/infra/auth/__tests__/config.test.ts
+++ b/libs/infra/auth/__tests__/config.test.ts
@@ -1,0 +1,88 @@
+/**
+ * What the config actually hands to Better Auth. These assertions look
+ * modest, and they are the only cheap way to catch the failure mode that
+ * matters here: a security option that is silently *not* passed through
+ * behaves exactly like a correctly configured one until it is needed.
+ *
+ * Better Auth's own limiter is off outside production
+ * (`enabled: options.rateLimit?.enabled ?? isProduction` in its context
+ * builder), so its behaviour cannot be exercised from a test process. Its
+ * chain-stripping and bucket-keying are the library's to prove; ours is
+ * that the options reach it.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { Database } from "@velachess/db";
+
+import { createAuth } from "../auth.ts";
+
+/** Never queried: the Drizzle adapter is lazy, and nothing here signs in. */
+const db = {} as Database;
+
+const base = {
+  db,
+  baseUrl: "https://chess.example.com",
+  secret: "test-secret-at-least-32-characters-long",
+  secureCookies: true,
+};
+
+describe("rate limiting", () => {
+  it("is stored in the database, under our table", () => {
+    // The default is process memory: per-instance, and reset by every
+    // deploy. A limit that forgets on restart is not a limit.
+    const { options } = createAuth(base);
+    expect(options.rateLimit).toEqual({
+      storage: "database",
+      modelName: "authRateLimits",
+    });
+  });
+});
+
+describe("trusted proxies", () => {
+  it("reach Better Auth's IP resolution when declared", () => {
+    const { options } = createAuth({ ...base, trustedProxies: ["10.0.0.0/8"] });
+    expect(options.advanced?.ipAddress?.trustedProxies).toEqual(["10.0.0.0/8"]);
+  });
+
+  it("are absent, not empty, when not declared", () => {
+    // An empty list is not the same statement as "no proxies": Better Auth
+    // reads an unset list as "the socket address is the client".
+    const { options } = createAuth(base);
+    expect(options.advanced?.ipAddress).toBeUndefined();
+  });
+});
+
+describe("Google sign-in", () => {
+  it("is offered only when credentials are configured", () => {
+    expect(createAuth(base).options.socialProviders?.google).toBeUndefined();
+
+    const configured = createAuth({
+      ...base,
+      google: { clientId: "id", clientSecret: "secret" },
+    });
+    expect(configured.options.socialProviders?.google).toMatchObject({
+      clientId: "id",
+      clientSecret: "secret",
+    });
+  });
+
+  it("is independent of the password sign-up switch", () => {
+    // The one that opens public sign-up without an SMTP dependency:
+    // `disableSignUp` governs emailAndPassword only.
+    const { options } = createAuth({
+      ...base,
+      google: { clientId: "id", clientSecret: "secret" },
+    });
+    expect(options.emailAndPassword?.disableSignUp).toBe(true);
+    expect(options.socialProviders?.google).toBeDefined();
+  });
+});
+
+describe("cookies", () => {
+  it("follow the configured transport, with no production override", () => {
+    expect(createAuth(base).options.advanced?.useSecureCookies).toBe(true);
+    expect(
+      createAuth({ ...base, secureCookies: false }).options.advanced?.useSecureCookies,
+    ).toBe(false);
+  });
+});

--- a/libs/infra/auth/__tests__/config.test.ts
+++ b/libs/infra/auth/__tests__/config.test.ts
@@ -78,6 +78,17 @@ describe("Google sign-in", () => {
   });
 });
 
+describe("the OAuth error fallback", () => {
+  it("points at the sign-in screen, not Better Auth's own /auth/error", () => {
+    // Reached only when there's no recoverable state to carry a caller's
+    // own errorCallbackURL — a state_mismatch or a malformed callback
+    // request. Left unset, this is baseURL + basePath + "/error", a
+    // path the SPA never routes.
+    const { options } = createAuth(base);
+    expect(options.onAPIError?.errorURL).toBe("https://chess.example.com/login");
+  });
+});
+
 describe("cookies", () => {
   it("follow the configured transport, with no production override", () => {
     expect(createAuth(base).options.advanced?.useSecureCookies).toBe(true);

--- a/libs/infra/auth/__tests__/env.test.ts
+++ b/libs/infra/auth/__tests__/env.test.ts
@@ -131,3 +131,70 @@ describe("trusted origins", () => {
     ).toThrowError(/VELACHESS_TRUSTED_ORIGINS.*not-an-origin/);
   });
 });
+
+describe("Google sign-in", () => {
+  it("is simply absent when unconfigured", () => {
+    expect(resolveAuthEnv({ VELACHESS_AUTH_SECRET: STRONG }).google).toBeUndefined();
+  });
+
+  it("is present when both halves are set", () => {
+    const resolved = resolveAuthEnv({
+      VELACHESS_AUTH_SECRET: STRONG,
+      GOOGLE_CLIENT_ID: "id.apps.googleusercontent.com",
+      GOOGLE_CLIENT_SECRET: "client-secret",
+    });
+    expect(resolved.google).toEqual({
+      clientId: "id.apps.googleusercontent.com",
+      clientSecret: "client-secret",
+    });
+  });
+
+  it("refuses to boot half-configured", () => {
+    // Better Auth would accept an empty credential and fail later, at the
+    // redirect — a broken button in production instead of a refusal here.
+    for (const half of [
+      { GOOGLE_CLIENT_ID: "id.apps.googleusercontent.com" },
+      { GOOGLE_CLIENT_SECRET: "client-secret" },
+    ]) {
+      expect(() =>
+        resolveAuthEnv({ VELACHESS_AUTH_SECRET: STRONG, ...half }),
+      ).toThrowError(/GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set together/);
+    }
+  });
+
+  it("never echoes the client secret in the refusal", () => {
+    try {
+      resolveAuthEnv({
+        VELACHESS_AUTH_SECRET: STRONG,
+        GOOGLE_CLIENT_SECRET: "leak-canary-google",
+      });
+      expect.unreachable("half-configured Google must throw");
+    } catch (error) {
+      expect((error as Error).message).not.toContain("leak-canary");
+    }
+  });
+});
+
+describe("trusted proxies", () => {
+  it("is absent unless declared — a direct deployment has no proxy", () => {
+    expect(
+      resolveAuthEnv({ VELACHESS_AUTH_SECRET: STRONG }).trustedProxies,
+    ).toBeUndefined();
+  });
+
+  it("parses a comma-separated list of addresses and ranges", () => {
+    const resolved = resolveAuthEnv({
+      VELACHESS_AUTH_SECRET: STRONG,
+      VELACHESS_TRUSTED_PROXIES: " 127.0.0.1 , 10.0.0.0/8 ",
+    });
+    expect(resolved.trustedProxies).toEqual(["127.0.0.1", "10.0.0.0/8"]);
+  });
+
+  it("treats an empty value as unset rather than as an empty proxy", () => {
+    const resolved = resolveAuthEnv({
+      VELACHESS_AUTH_SECRET: STRONG,
+      VELACHESS_TRUSTED_PROXIES: " , ",
+    });
+    expect(resolved.trustedProxies).toBeUndefined();
+  });
+});

--- a/libs/infra/auth/auth.ts
+++ b/libs/infra/auth/auth.ts
@@ -58,6 +58,10 @@ export interface AuthConfig {
   trustedProxies?: string[];
 }
 
+/** Google's authorized-redirect-URI path. Exported so the pinned test and
+ * the Google Cloud console value in self-host.md have one source. */
+export const GOOGLE_CALLBACK_PATH = "/api/auth/callback/google";
+
 /** One Better Auth instance per process, built from injected deps the way
  * apps/api builds everything else — never from ambient env reads here. */
 export function createAuth(config: AuthConfig) {
@@ -102,6 +106,10 @@ export function createAuth(config: AuthConfig) {
             google: {
               clientId: config.google.clientId,
               clientSecret: config.google.clientSecret,
+              // Explicit, under /api: Better Auth's default derives this
+              // from baseURL + basePath ("/auth"), with no /api prefix —
+              // a second proxy rule this avoids needing.
+              redirectURI: `${config.baseUrl}${GOOGLE_CALLBACK_PATH}`,
             },
           },
         }

--- a/libs/infra/auth/auth.ts
+++ b/libs/infra/auth/auth.ts
@@ -74,6 +74,12 @@ export function createAuth(config: AuthConfig) {
     secret: config.secret,
     trustedOrigins: config.trustedOrigins ?? [config.baseUrl],
 
+    // Default is baseURL + basePath + "/error" (e.g. /auth/error) — a
+    // path this SPA never routes, so an OAuth failure that has no
+    // recoverable state (state_mismatch, invalid_callback_request) 404s
+    // instead of reaching the sign-in screen's own error copy.
+    onAPIError: { errorURL: `${config.baseUrl}/login` },
+
     database: drizzleAdapter(config.db, {
       provider: "pg",
       // Keyed by the modelName each model maps to below — the adapter

--- a/libs/infra/auth/auth.ts
+++ b/libs/infra/auth/auth.ts
@@ -34,6 +34,28 @@ export interface AuthConfig {
    * separate signup-enabled instance never mounted on HTTP (main.ts).
    */
   allowSignUp?: boolean;
+  /**
+   * Google OAuth, when configured. Absent means the provider is simply not
+   * offered — the button disappears, nothing throws.
+   *
+   * This is what opens public sign-up without touching the password path:
+   * `disableSignUp` above governs `emailAndPassword` only, and social
+   * providers carry their own (`disableImplicitSignUp`, default false).
+   * Verified in better-auth 1.7.0, not assumed.
+   */
+  google?: { clientId: string; clientSecret: string };
+  /**
+   * Addresses of the reverse proxies in front of this API.
+   *
+   * Load-bearing, and quiet when wrong. Better Auth keys its rate limiter
+   * by client IP; when it cannot resolve one it falls back to a single
+   * shared bucket per path (`NO_TRUSTED_IP_KEY` in its rate-limiter) and
+   * only logs a warning. Behind a proxy with this unset, the whole site's
+   * sign-in shares one 3-per-10s budget — three attempts by anyone lock
+   * out everyone, and the symptom reads as "I can't log in", never as a
+   * misconfigured limiter.
+   */
+  trustedProxies?: string[];
 }
 
 /** One Better Auth instance per process, built from injected deps the way
@@ -57,6 +79,7 @@ export function createAuth(config: AuthConfig) {
         sessions: schema.sessions,
         authAccounts: schema.authAccounts,
         verifications: schema.verifications,
+        authRateLimits: schema.authRateLimits,
       },
     }),
 
@@ -66,6 +89,39 @@ export function createAuth(config: AuthConfig) {
       // is the documented option for exactly this
       // (@better-auth/core dist/types/init-options.d.mts, @default false).
       disableSignUp: !config.allowSignUp,
+    },
+
+    // Social sign-in, and the only route to public sign-up that does not
+    // drag in password reset, email verification and an SMTP dependency.
+    // The whole key is conditional so an unconfigured provider is absent
+    // rather than present with empty credentials, which Better Auth would
+    // accept and then fail on at redirect time.
+    ...(config.google
+      ? {
+          socialProviders: {
+            google: {
+              clientId: config.google.clientId,
+              clientSecret: config.google.clientSecret,
+            },
+          },
+        }
+      : {}),
+
+    // Auth throttling belongs to Better Auth, not to a second limiter in
+    // front of it: it already applies stricter built-in rules to the
+    // sensitive paths (3 per 10s on /sign-in*, /sign-up*, /change-password*
+    // and /change-email*; 3 per 60s on password reset, verification and
+    // OTP — getDefaultSpecialRules in its rate-limiter). Declaring those
+    // again here would only drift from the library on an upgrade.
+    //
+    // What DOES need saying is the storage: the default is process memory,
+    // which resets on deploy and is per-instance. `database` makes the
+    // limit hold across restarts and across however many API processes
+    // run. The table prunes itself (`deleteExpiredRows` inside consume) —
+    // no cleanup job.
+    rateLimit: {
+      storage: "database",
+      modelName: "authRateLimits",
     },
 
     // Our tables, our names. Type inference keeps Better Auth's names
@@ -94,6 +150,11 @@ export function createAuth(config: AuthConfig) {
       // has no TLS). Never weakened in production to ease development —
       // development passes `secureCookies: false` instead.
       useSecureCookies: config.secureCookies,
+      // See AuthConfig.trustedProxies: without this, every client behind
+      // the proxy collapses into one rate-limit bucket.
+      ...(config.trustedProxies
+        ? { ipAddress: { trustedProxies: config.trustedProxies } }
+        : {}),
     },
   });
 }

--- a/libs/infra/auth/env.ts
+++ b/libs/infra/auth/env.ts
@@ -3,7 +3,12 @@
  * throws a message naming the variable and requirement to fix. Pure
  * (`resolveAuthEnv(env)` takes env as a value) so main.ts stays wiring.
  * Never echoes `VELACHESS_AUTH_SECRET`'s value in any error or log.
+ *
+ * `production` is computed independently of envalid's own isProduction,
+ * which treats an unset NODE_ENV as production — this repo's opposite.
  */
+
+import { cleanEnv, EnvError, makeValidator, str } from "envalid";
 
 /** The .env.example placeholder — booting production with it means the
  * file was copied verbatim, which is indistinguishable from no secret. */
@@ -19,8 +24,7 @@ export interface ResolvedAuthEnv {
   /** Google OAuth credentials, when both are present. Absent means the
    * provider is simply not offered. */
   google?: { clientId: string; clientSecret: string };
-  /** Addresses of the reverse proxies in front of the API, from
-   * VELACHESS_TRUSTED_PROXIES. Absent behind a proxy collapses every
+  /** Reverse proxy addresses. Absent behind a real proxy collapses every
    * client into one rate-limit bucket — see AuthConfig.trustedProxies. */
   trustedProxies?: string[];
   /** Production served over plain http — legal for a LAN self-host, but
@@ -28,47 +32,66 @@ export interface ResolvedAuthEnv {
   insecureProductionTransport: boolean;
 }
 
-export function resolveAuthEnv(env: Record<string, string | undefined>): ResolvedAuthEnv {
-  const production = env["NODE_ENV"] === "production";
-
-  // The secret signs session tokens; it is permanent infrastructure, not
-  // a first-run convenience (contrast the bootstrap password, which is
-  // designed to be removed — docs/how-to/self-host.md). 32 characters is
-  // Better Auth's own floor for a real secret, enforced in every mode so
-  // development cannot drift onto a value production would reject.
-  const secret = env["VELACHESS_AUTH_SECRET"];
-  if (!secret) {
-    throw new Error(
-      "VELACHESS_AUTH_SECRET is required — it signs session tokens. " +
-        "Generate one: openssl rand -base64 32",
-    );
-  }
-  if (secret.length < 32) {
-    throw new Error(
+// 32 characters is Better Auth's own floor for a real secret — str() has
+// no minLength, so this is the one var that needs a custom parser.
+const authSecret = makeValidator<string>((input) => {
+  if (input.length < 32) {
+    throw new EnvError(
       "VELACHESS_AUTH_SECRET is too short — use at least 32 characters. " +
         "Generate one: openssl rand -base64 32",
     );
   }
-  if (production && secret === EXAMPLE_SECRET) {
+  return input;
+});
+
+/** envalid's default reporter logs and calls process.exit(1); this
+ * throws the first underlying error instead, so a bad env is provable
+ * without a process. */
+function throwFirstError({ errors }: { errors: Record<string, Error> }): void {
+  const [firstError] = Object.values(errors);
+  if (firstError) throw firstError;
+}
+
+export function resolveAuthEnv(env: Record<string, string | undefined>): ResolvedAuthEnv {
+  const production = env["NODE_ENV"] === "production";
+
+  const cleaned = cleanEnv(
+    env,
+    {
+      VELACHESS_AUTH_SECRET: authSecret({
+        desc:
+          "VELACHESS_AUTH_SECRET is required — it signs session tokens. " +
+          "Generate one: openssl rand -base64 32",
+      }),
+      // A bare default, not devDefault: whether production may rely on
+      // it is the policy check below, not a shape one.
+      VELACHESS_BASE_URL: str({ default: "http://localhost:3000" }),
+      VELACHESS_TRUSTED_ORIGINS: str({ default: undefined }),
+      GOOGLE_CLIENT_ID: str({ default: undefined }),
+      GOOGLE_CLIENT_SECRET: str({ default: undefined }),
+      VELACHESS_TRUSTED_PROXIES: str({ default: undefined }),
+    },
+    { reporter: throwFirstError },
+  );
+
+  if (production && cleaned.VELACHESS_AUTH_SECRET === EXAMPLE_SECRET) {
     throw new Error(
       "VELACHESS_AUTH_SECRET is still the .env.example placeholder — " +
         "production needs its own secret. Generate one: openssl rand -base64 32",
     );
   }
 
-  // Production must say where it is served; a silently-defaulted
-  // localhost baseURL in production produces cookies and trusted origins
-  // for a host nobody is on. Development gets the conventional default.
-  const rawBaseUrl = env["VELACHESS_BASE_URL"];
-  if (production && !rawBaseUrl) {
+  // Against the raw value, not the defaulted one — production must say
+  // where it's served, not inherit the machine-local default.
+  if (production && env["VELACHESS_BASE_URL"] === undefined) {
     throw new Error(
       "VELACHESS_BASE_URL is required in production — the public URL the " +
         "app is served on (e.g. https://chess.example.com, or " +
         "http://localhost:3000 for a machine-local install)",
     );
   }
-  const baseUrl = rawBaseUrl ?? "http://localhost:3000";
 
+  const baseUrl = cleaned.VELACHESS_BASE_URL;
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
@@ -79,19 +102,13 @@ export function resolveAuthEnv(env: Record<string, string | undefined>): Resolve
     throw new Error(`VELACHESS_BASE_URL must be http:// or https://, got: ${baseUrl}`);
   }
 
-  // Secure follows the actual transport. Never weakened the other way:
-  // an https deployment always gets Secure cookies, and there is no
-  // switch to turn that off for development convenience — development
-  // uses an http URL, which has no TLS for Secure to bind to.
+  // No switch to weaken this for convenience — https always means Secure.
   const secureCookies = parsed.protocol === "https:";
 
-  // Origins the auth endpoints will accept browser requests from. The
-  // app's own origin is always trusted; anything beyond it (a separate
-  // web origin in front of the API) must be listed deliberately.
+  // The app's own origin is always trusted; anything beyond it is deliberate.
   const trustedOrigins = [parsed.origin];
-  const extraOrigins = env["VELACHESS_TRUSTED_ORIGINS"];
-  if (extraOrigins) {
-    for (const entry of extraOrigins.split(",")) {
+  if (cleaned.VELACHESS_TRUSTED_ORIGINS) {
+    for (const entry of cleaned.VELACHESS_TRUSTED_ORIGINS.split(",")) {
       const candidate = entry.trim();
       if (!candidate) continue;
       try {
@@ -104,13 +121,10 @@ export function resolveAuthEnv(env: Record<string, string | undefined>): Resolve
     }
   }
 
-  // Google OAuth is optional, but half-configured is not: one variable
-  // without the other means somebody intended to enable sign-in with
-  // Google and stopped halfway. Better Auth would accept the empty
-  // credential and only fail at the redirect, as a broken button in
-  // production — so it fails here, at boot, where it is legible.
-  const googleId = env["GOOGLE_CLIENT_ID"]?.trim();
-  const googleSecret = env["GOOGLE_CLIENT_SECRET"]?.trim();
+  // Half-configured means someone intended Google and stopped halfway —
+  // Better Auth would accept the empty half and only fail at the redirect.
+  const googleId = cleaned.GOOGLE_CLIENT_ID?.trim();
+  const googleSecret = cleaned.GOOGLE_CLIENT_SECRET?.trim();
   if (Boolean(googleId) !== Boolean(googleSecret)) {
     throw new Error(
       "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set together — " +
@@ -122,17 +136,12 @@ export function resolveAuthEnv(env: Record<string, string | undefined>): Resolve
       ? { clientId: googleId, clientSecret: googleSecret }
       : undefined;
 
-  // Reverse-proxy addresses, so Better Auth trusts X-Forwarded-For from
-  // them and only them. Left unset on a direct-to-internet deployment,
-  // where the socket address is already the client's.
-  const rawProxies = env["VELACHESS_TRUSTED_PROXIES"];
-  const trustedProxies = rawProxies
-    ?.split(",")
+  const trustedProxies = cleaned.VELACHESS_TRUSTED_PROXIES?.split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
 
   return {
-    secret,
+    secret: cleaned.VELACHESS_AUTH_SECRET,
     baseUrl,
     secureCookies,
     trustedOrigins,

--- a/libs/infra/auth/env.ts
+++ b/libs/infra/auth/env.ts
@@ -8,7 +8,7 @@
  * which treats an unset NODE_ENV as production — this repo's opposite.
  */
 
-import { cleanEnv, EnvError, makeValidator, str } from "envalid";
+import { cleanEnv, EnvError, makeValidator, str, url } from "envalid";
 
 /** The .env.example placeholder — booting production with it means the
  * file was copied verbatim, which is indistinguishable from no secret. */
@@ -44,14 +44,6 @@ const authSecret = makeValidator<string>((input) => {
   return input;
 });
 
-/** envalid's default reporter logs and calls process.exit(1); this
- * throws the first underlying error instead, so a bad env is provable
- * without a process. */
-function throwFirstError({ errors }: { errors: Record<string, Error> }): void {
-  const [firstError] = Object.values(errors);
-  if (firstError) throw firstError;
-}
-
 export function resolveAuthEnv(env: Record<string, string | undefined>): ResolvedAuthEnv {
   const production = env["NODE_ENV"] === "production";
 
@@ -65,13 +57,27 @@ export function resolveAuthEnv(env: Record<string, string | undefined>): Resolve
       }),
       // A bare default, not devDefault: whether production may rely on
       // it is the policy check below, not a shape one.
-      VELACHESS_BASE_URL: str({ default: "http://localhost:3000" }),
+      VELACHESS_BASE_URL: url({ default: "http://localhost:3000" }),
       VELACHESS_TRUSTED_ORIGINS: str({ default: undefined }),
       GOOGLE_CLIENT_ID: str({ default: undefined }),
       GOOGLE_CLIENT_SECRET: str({ default: undefined }),
       VELACHESS_TRUSTED_PROXIES: str({ default: undefined }),
     },
-    { reporter: throwFirstError },
+    {
+      // envalid's default reporter logs and calls process.exit(1); this
+      // throws instead, so a bad env is provable without a process.
+      // VELACHESS_BASE_URL gets its own message — url()'s own doesn't
+      // name the variable.
+      reporter: ({ errors }) => {
+        if (errors["VELACHESS_BASE_URL"]) {
+          throw new Error(
+            `VELACHESS_BASE_URL is not a valid URL: ${env["VELACHESS_BASE_URL"]}`,
+          );
+        }
+        const [firstError] = Object.values(errors);
+        if (firstError) throw firstError;
+      },
+    },
   );
 
   if (production && cleaned.VELACHESS_AUTH_SECRET === EXAMPLE_SECRET) {
@@ -91,13 +97,9 @@ export function resolveAuthEnv(env: Record<string, string | undefined>): Resolve
     );
   }
 
+  // url() only checks that it parses — the scheme restriction is ours.
   const baseUrl = cleaned.VELACHESS_BASE_URL;
-  let parsed: URL;
-  try {
-    parsed = new URL(baseUrl);
-  } catch {
-    throw new Error(`VELACHESS_BASE_URL is not a valid URL: ${baseUrl}`);
-  }
+  const parsed = new URL(baseUrl);
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
     throw new Error(`VELACHESS_BASE_URL must be http:// or https://, got: ${baseUrl}`);
   }

--- a/libs/infra/auth/env.ts
+++ b/libs/infra/auth/env.ts
@@ -16,6 +16,13 @@ export interface ResolvedAuthEnv {
   secureCookies: boolean;
   /** The baseUrl origin plus any VELACHESS_TRUSTED_ORIGINS entries. */
   trustedOrigins: string[];
+  /** Google OAuth credentials, when both are present. Absent means the
+   * provider is simply not offered. */
+  google?: { clientId: string; clientSecret: string };
+  /** Addresses of the reverse proxies in front of the API, from
+   * VELACHESS_TRUSTED_PROXIES. Absent behind a proxy collapses every
+   * client into one rate-limit bucket — see AuthConfig.trustedProxies. */
+  trustedProxies?: string[];
   /** Production served over plain http — legal for a LAN self-host, but
    * main.ts warns loudly: session cookies ride unencrypted. */
   insecureProductionTransport: boolean;
@@ -97,11 +104,40 @@ export function resolveAuthEnv(env: Record<string, string | undefined>): Resolve
     }
   }
 
+  // Google OAuth is optional, but half-configured is not: one variable
+  // without the other means somebody intended to enable sign-in with
+  // Google and stopped halfway. Better Auth would accept the empty
+  // credential and only fail at the redirect, as a broken button in
+  // production — so it fails here, at boot, where it is legible.
+  const googleId = env["GOOGLE_CLIENT_ID"]?.trim();
+  const googleSecret = env["GOOGLE_CLIENT_SECRET"]?.trim();
+  if (Boolean(googleId) !== Boolean(googleSecret)) {
+    throw new Error(
+      "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set together — " +
+        "set both to enable Google sign-in, or neither to disable it",
+    );
+  }
+  const google =
+    googleId && googleSecret
+      ? { clientId: googleId, clientSecret: googleSecret }
+      : undefined;
+
+  // Reverse-proxy addresses, so Better Auth trusts X-Forwarded-For from
+  // them and only them. Left unset on a direct-to-internet deployment,
+  // where the socket address is already the client's.
+  const rawProxies = env["VELACHESS_TRUSTED_PROXIES"];
+  const trustedProxies = rawProxies
+    ?.split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
   return {
     secret,
     baseUrl,
     secureCookies,
     trustedOrigins,
+    ...(google ? { google } : {}),
+    ...(trustedProxies?.length ? { trustedProxies } : {}),
     insecureProductionTransport: production && !secureCookies,
   };
 }

--- a/libs/infra/auth/package.json
+++ b/libs/infra/auth/package.json
@@ -14,7 +14,8 @@
     "@better-auth/drizzle-adapter": "1.7.0",
     "@velachess/db": "workspace:*",
     "better-auth": "1.7.0",
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.45.2",
+    "envalid": "^8.2.0"
   },
   "type": "module",
   "exports": {

--- a/libs/infra/db/__tests__/queries.test.ts
+++ b/libs/infra/db/__tests__/queries.test.ts
@@ -69,11 +69,35 @@ describe("packages/db (games + tracked accounts)", () => {
   afterAll(() => close());
 
   it("saveGames twice with the same Chess.com game inserts it once", async () => {
-    const first = await saveGames(db, [chessComGame()]);
-    const second = await saveGames(db, [chessComGame()]);
+    const account = await upsertTrackedAccount(db, ownerId, "chess_com", "Test-Player");
+    const first = await saveGames(db, [chessComGame()], { accountId: account.id });
+    const second = await saveGames(db, [chessComGame()], { accountId: account.id });
 
     expect(first.inserted).toBe(1);
     expect(second.inserted).toBe(0);
+  });
+
+  it("two accounts tracking the same real game both keep their own copy", async () => {
+    // The bug this constraint fixes: two different tracked accounts (any
+    // two users, or the same user twice) independently sync the same
+    // real chess.com game. Each must get its own complete history —
+    // dedup happens within an account, never across accounts.
+    const other = (await createUser(db)).id;
+    const accountA = await upsertTrackedAccount(db, ownerId, "chess_com", "Test-Player");
+    const accountB = await upsertTrackedAccount(db, other, "chess_com", "Test-Player");
+
+    const first = await saveGames(db, [chessComGame()], { accountId: accountA.id });
+    const second = await saveGames(db, [chessComGame()], { accountId: accountB.id });
+
+    expect(first.inserted).toBe(1);
+    expect(second.inserted).toBe(1);
+
+    const [rowsA, rowsB] = await Promise.all([
+      listGames(db, { accountId: accountA.id }),
+      listGames(db, { accountId: accountB.id }),
+    ]);
+    expect(rowsA).toHaveLength(1);
+    expect(rowsB).toHaveLength(1);
   });
 
   it("the same pasted PGN twice with no account inserts it once — proves NULLS NOT DISTINCT is applied", async () => {

--- a/libs/infra/db/__tests__/rate-limit.test.ts
+++ b/libs/infra/db/__tests__/rate-limit.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+/**
+ * The limiter's arithmetic, proved against a real Postgres rather than
+ * reasoned about: budgets are per (policy, subject), a refusal reports a
+ * usable wait, and an expired window starts over instead of staying shut.
+ */
+import { sql } from "drizzle-orm";
+import { afterAll, expect, it } from "vitest";
+
+import { consumeRateLimit, type RateLimitPolicy } from "@velachess/db";
+
+import { createTestDb } from "./test-db.ts";
+
+const { db, close } = await createTestDb();
+afterAll(close);
+
+const policy = (over: Partial<RateLimitPolicy> = {}): RateLimitPolicy => ({
+  name: "test",
+  max: 3,
+  windowSeconds: 60,
+  ...over,
+});
+
+it("spends exactly `max` requests, then refuses", async () => {
+  const rule = policy({ name: "spend" });
+
+  for (let i = 0; i < rule.max; i++) {
+    expect(await consumeRateLimit(db, "alice", rule)).toEqual({
+      allowed: true,
+      retryAfterSeconds: 0,
+    });
+  }
+
+  const refused = await consumeRateLimit(db, "alice", rule);
+  expect(refused.allowed).toBe(false);
+  // Never zero: a client told to retry in 0s retries immediately, which is
+  // the behaviour the refusal exists to prevent.
+  expect(refused.retryAfterSeconds).toBeGreaterThan(0);
+  expect(refused.retryAfterSeconds).toBeLessThanOrEqual(rule.windowSeconds);
+});
+
+it("gives every subject its own budget", async () => {
+  const rule = policy({ name: "subjects", max: 1 });
+
+  expect((await consumeRateLimit(db, "bob", rule)).allowed).toBe(true);
+  expect((await consumeRateLimit(db, "bob", rule)).allowed).toBe(false);
+  // Bob being over his limit says nothing about Carol.
+  expect((await consumeRateLimit(db, "carol", rule)).allowed).toBe(true);
+});
+
+it("gives every policy its own budget for the same subject", async () => {
+  const cheap = policy({ name: "cheap", max: 1 });
+  const costly = policy({ name: "costly", max: 1 });
+
+  expect((await consumeRateLimit(db, "dave", cheap)).allowed).toBe(true);
+  expect((await consumeRateLimit(db, "dave", cheap)).allowed).toBe(false);
+  // Exhausting the cheap budget must not close the costly one — the keys
+  // are namespaced by policy name, not shared per user.
+  expect((await consumeRateLimit(db, "dave", costly)).allowed).toBe(true);
+});
+
+it("reopens once the window has passed", async () => {
+  // A one-second window, so the test waits rather than mocks the clock:
+  // `now()` here is Postgres's, and a faked JS clock would prove nothing.
+  const rule = policy({ name: "window", max: 1, windowSeconds: 1 });
+
+  expect((await consumeRateLimit(db, "erin", rule)).allowed).toBe(true);
+  expect((await consumeRateLimit(db, "erin", rule)).allowed).toBe(false);
+
+  await new Promise((resolve) => setTimeout(resolve, 1100));
+  expect((await consumeRateLimit(db, "erin", rule)).allowed).toBe(true);
+});
+
+it("keeps a blocked caller's wait measured from the last accepted request", async () => {
+  // The rejected attempt must not push `last_request` forward — otherwise
+  // a client that keeps retrying extends its own lockout indefinitely.
+  const rule = policy({ name: "no-extend", max: 1, windowSeconds: 10 });
+
+  await consumeRateLimit(db, "frank", rule);
+  const first = await consumeRateLimit(db, "frank", rule);
+  await new Promise((resolve) => setTimeout(resolve, 1100));
+  const later = await consumeRateLimit(db, "frank", rule);
+
+  expect(first.allowed).toBe(false);
+  expect(later.allowed).toBe(false);
+  expect(later.retryAfterSeconds).toBeLessThan(first.retryAfterSeconds);
+});
+
+it("holds one row per key however many requests arrive", async () => {
+  const rule = policy({ name: "rows", max: 2, windowSeconds: 1 });
+
+  for (let i = 0; i < 6; i++) {
+    await consumeRateLimit(db, "grace", rule);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  // The reason this table needs no pruning: rows are bounded by subjects,
+  // not by elapsed windows.
+  // Same driver divergence the query layer normalizes: postgres-js hands
+  // back the rows, PGlite hands back `{ rows }`.
+  const result = (await db.execute(
+    sql`select count(*)::int as n from rate_limits where key = ${"rows:grace"}`,
+  )) as unknown as { n: number }[] | { rows: { n: number }[] };
+  const rows = Array.isArray(result) ? result : result.rows;
+  expect(Number(rows[0]!.n)).toBe(1);
+});

--- a/libs/infra/db/index.ts
+++ b/libs/infra/db/index.ts
@@ -18,6 +18,7 @@ export * from "./queries/training-counts.ts";
 export * from "./queries/drill.ts";
 export * from "./queries/engine-drills.ts";
 export * from "./queries/scheduler.ts";
+export * from "./queries/rate-limit.ts";
 export * from "./queries/pagination.ts";
 export * from "./queries/status.ts";
 export * from "./advisory-lock.ts";

--- a/libs/infra/db/migrations/0016_rate_limits.sql
+++ b/libs/infra/db/migrations/0016_rate_limits.sql
@@ -1,13 +1,4 @@
--- Two limiters, two tables, on purpose.
---
--- "auth_rate_limits" is Better Auth's own — its shape is dictated by the
--- library (key / count / last_request as epoch millis, hence bigint) and
--- it is pointed at by `rateLimit: { storage: "database", modelName:
--- "authRateLimits" }`. It prunes itself inside consume; nothing to schedule.
---
--- "rate_limits" is ours, for the application's routes, keyed by the userId
--- the session already proved. One row per key, updated in place: the row
--- count is bounded by the number of users, not by elapsed time.
+-- Two limiters, two tables — see libs/infra/db/schema.ts for why.
 CREATE TABLE "auth_rate_limits" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"key" text NOT NULL,

--- a/libs/infra/db/migrations/0016_rate_limits.sql
+++ b/libs/infra/db/migrations/0016_rate_limits.sql
@@ -1,0 +1,23 @@
+-- Two limiters, two tables, on purpose.
+--
+-- "auth_rate_limits" is Better Auth's own — its shape is dictated by the
+-- library (key / count / last_request as epoch millis, hence bigint) and
+-- it is pointed at by `rateLimit: { storage: "database", modelName:
+-- "authRateLimits" }`. It prunes itself inside consume; nothing to schedule.
+--
+-- "rate_limits" is ours, for the application's routes, keyed by the userId
+-- the session already proved. One row per key, updated in place: the row
+-- count is bounded by the number of users, not by elapsed time.
+CREATE TABLE "auth_rate_limits" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"key" text NOT NULL,
+	"count" integer NOT NULL,
+	"last_request" bigint NOT NULL,
+	CONSTRAINT "auth_rate_limits_key_unique" UNIQUE("key")
+);
+--> statement-breakpoint
+CREATE TABLE "rate_limits" (
+	"key" text PRIMARY KEY NOT NULL,
+	"count" integer NOT NULL,
+	"last_request" timestamp with time zone NOT NULL
+);

--- a/libs/infra/db/migrations/0017_account_scoped_game_dedup.sql
+++ b/libs/infra/db/migrations/0017_account_scoped_game_dedup.sql
@@ -1,0 +1,2 @@
+DROP INDEX "games_source_external_id";--> statement-breakpoint
+CREATE UNIQUE INDEX "games_account_source_external_id" ON "games" USING btree ("account_id","source","external_id") WHERE "games"."external_id" is not null;

--- a/libs/infra/db/migrations/meta/0016_snapshot.json
+++ b/libs/infra/db/migrations/meta/0016_snapshot.json
@@ -1,0 +1,1977 @@
+{
+  "id": "f7470c66-9380-4476-a84b-7e93f11b0eb5",
+  "prevId": "2ee2a87c-ba83-4604-9681-d5e5c9471e5e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_progress": {
+      "name": "analysis_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_progress_run_index": {
+          "name": "analysis_progress_run_index",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_progress_game_seq": {
+          "name": "analysis_progress_game_seq",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_progress_game_id_games_id_fk": {
+          "name": "analysis_progress_game_id_games_id_fk",
+          "tableFrom": "analysis_progress",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_accounts_user_id": {
+          "name": "auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_accounts_provider_account": {
+          "name": "auth_accounts_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_rate_limits_key_unique": {
+          "name": "auth_rate_limits_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due": {
+          "name": "due",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stability": {
+          "name": "stability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_steps": {
+          "name": "learning_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phase": {
+          "name": "phase",
+          "type": "card_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cards_exercise_id": {
+          "name": "cards_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cards_due": {
+          "name": "cards_due",
+          "columns": [
+            {
+              "expression": "due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cards_exercise_id_exercises_id_fk": {
+          "name": "cards_exercise_id_exercises_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deviations": {
+      "name": "deviations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repertoire_name_snapshot": {
+          "name": "repertoire_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_name_snapshot": {
+          "name": "chapter_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "deviation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_book_plies": {
+          "name": "in_book_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_plies": {
+          "name": "game_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played_san": {
+          "name": "played_san",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cp_loss": {
+          "name": "cp_loss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_category": {
+          "name": "engine_category",
+          "type": "engine_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drillable": {
+          "name": "drillable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deviations_game_repertoire": {
+          "name": "deviations_game_repertoire",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_repertoire_id": {
+          "name": "deviations_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_chapter_id": {
+          "name": "deviations_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deviations_game_id_games_id_fk": {
+          "name": "deviations_game_id_games_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deviations_repertoire_id_repertoires_id_fk": {
+          "name": "deviations_repertoire_id_repertoires_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deviations_chapter_id_repertoire_chapters_id_fk": {
+          "name": "deviations_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_responses": {
+      "name": "training_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "training_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "training_responses_exercise_id": {
+          "name": "training_responses_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_responses_exercise_id_exercises_id_fk": {
+          "name": "training_responses_exercise_id_exercises_id_fk",
+          "tableFrom": "training_responses",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_sources": {
+      "name": "exercise_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "drill_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviation_id": {
+          "name": "deviation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "exercise_sources_deviation": {
+          "name": "exercise_sources_deviation",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"deviation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_ply": {
+          "name": "exercise_sources_ply",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"game_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter": {
+          "name": "exercise_sources_chapter",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"chapter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_deviation_id": {
+          "name": "exercise_sources_deviation_id",
+          "columns": [
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_game_id": {
+          "name": "exercise_sources_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter_id": {
+          "name": "exercise_sources_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_sources_exercise_id_exercises_id_fk": {
+          "name": "exercise_sources_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_deviation_id_deviations_id_fk": {
+          "name": "exercise_sources_deviation_id_deviations_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "deviations",
+          "columnsFrom": ["deviation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_game_id_games_id_fk": {
+          "name": "exercise_sources_game_id_games_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_chapter_id_repertoire_chapters_id_fk": {
+          "name": "exercise_sources_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exercise_sources_origin_shape": {
+          "name": "exercise_sources_origin_shape",
+          "value": "(\"exercise_sources\".\"origin\" = 'repertoire-deviation'\n             AND \"exercise_sources\".\"deviation_id\" IS NOT NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'engine-blunder'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NOT NULL AND \"exercise_sources\".\"ply\" IS NOT NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'repertoire-line'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exercises_user_position": {
+          "name": "exercises_user_position",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_user_id": {
+          "name": "exercises_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_analyses": {
+      "name": "game_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine_version": {
+          "name": "engine_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "positions": {
+          "name": "positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_analyses_game_id": {
+          "name": "game_analyses_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_analyses_game_id_games_id_fk": {
+          "name": "game_analyses_game_id_games_id_fk",
+          "tableFrom": "game_analyses",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "game_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perspective": {
+          "name": "perspective",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "white_name": {
+          "name": "white_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "white_rating": {
+          "name": "white_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_name": {
+          "name": "black_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "black_rating": {
+          "name": "black_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "game_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_initial_seconds": {
+          "name": "time_control_initial_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_increment_seconds": {
+          "name": "time_control_increment_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_raw": {
+          "name": "time_control_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_eco": {
+          "name": "opening_eco",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_name": {
+          "name": "opening_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_url": {
+          "name": "opening_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination": {
+          "name": "termination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_clocks": {
+          "name": "has_clocks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_pgn": {
+          "name": "raw_pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movetext_hash": {
+          "name": "movetext_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "games_source_external_id": {
+          "name": "games_source_external_id",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"games\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_account_played_at": {
+          "name": "games_account_played_at",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_account_id_tracked_accounts_id_fk": {
+          "name": "games_account_id_tracked_accounts_id_fk",
+          "tableFrom": "games",
+          "tableTo": "tracked_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_account_movetext": {
+          "name": "games_account_movetext",
+          "nullsNotDistinct": true,
+          "columns": ["account_id", "movetext_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoire_chapters": {
+      "name": "repertoire_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn": {
+          "name": "pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting_fen": {
+          "name": "starting_fen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoire_chapters_repertoire_id": {
+          "name": "repertoire_chapters_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoire_chapters_repertoire_id_repertoires_id_fk": {
+          "name": "repertoire_chapters_repertoire_id_repertoires_id_fk",
+          "tableFrom": "repertoire_chapters",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repertoire_chapters_repertoire_sort": {
+          "name": "repertoire_chapters_repertoire_sort",
+          "nullsNotDistinct": false,
+          "columns": ["repertoire_id", "sort_order"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoires": {
+      "name": "repertoires",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "repertoire_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoires_user_id": {
+          "name": "repertoires_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoires_user_id_users_id_fk": {
+          "name": "repertoires_user_id_users_id_fk",
+          "tableFrom": "repertoires",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id": {
+          "name": "sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_accounts": {
+      "name": "tracked_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flair": {
+          "name": "flair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_accounts_user_platform_username": {
+          "name": "tracked_accounts_user_platform_username",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_accounts_user_id": {
+          "name": "tracked_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracked_accounts_user_id_users_id_fk": {
+          "name": "tracked_accounts_user_id_users_id_fk",
+          "tableFrom": "tracked_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier": {
+          "name": "verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.card_phase": {
+      "name": "card_phase",
+      "schema": "public",
+      "values": ["new", "learning", "review", "relearning"]
+    },
+    "public.deviation_type": {
+      "name": "deviation_type",
+      "schema": "public",
+      "values": ["deviation", "gap", "book-ended", "completed", "unmatched"]
+    },
+    "public.training_grade": {
+      "name": "training_grade",
+      "schema": "public",
+      "values": ["again", "hard", "good", "easy"]
+    },
+    "public.drill_origin": {
+      "name": "drill_origin",
+      "schema": "public",
+      "values": ["repertoire-deviation", "engine-blunder", "repertoire-line"]
+    },
+    "public.engine_category": {
+      "name": "engine_category",
+      "schema": "public",
+      "values": ["ok", "inaccuracy", "mistake", "blunder"]
+    },
+    "public.game_source": {
+      "name": "game_source",
+      "schema": "public",
+      "values": ["chess_com", "lichess", "pgn"]
+    },
+    "public.perspective": {
+      "name": "perspective",
+      "schema": "public",
+      "values": ["white", "black"]
+    },
+    "public.platform": {
+      "name": "platform",
+      "schema": "public",
+      "values": ["chess_com", "lichess"]
+    },
+    "public.repertoire_source": {
+      "name": "repertoire_source",
+      "schema": "public",
+      "values": ["manual", "extracted"]
+    },
+    "public.game_result": {
+      "name": "game_result",
+      "schema": "public",
+      "values": ["1-0", "0-1", "1/2-1/2", "*"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/migrations/meta/0017_snapshot.json
+++ b/libs/infra/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1983 @@
+{
+  "id": "4d81601d-00fe-4127-8630-7410d28ee7cc",
+  "prevId": "f7470c66-9380-4476-a84b-7e93f11b0eb5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_progress": {
+      "name": "analysis_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_progress_run_index": {
+          "name": "analysis_progress_run_index",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_progress_game_seq": {
+          "name": "analysis_progress_game_seq",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_progress_game_id_games_id_fk": {
+          "name": "analysis_progress_game_id_games_id_fk",
+          "tableFrom": "analysis_progress",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_accounts_user_id": {
+          "name": "auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_accounts_provider_account": {
+          "name": "auth_accounts_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_rate_limits_key_unique": {
+          "name": "auth_rate_limits_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due": {
+          "name": "due",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stability": {
+          "name": "stability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_steps": {
+          "name": "learning_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phase": {
+          "name": "phase",
+          "type": "card_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cards_exercise_id": {
+          "name": "cards_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cards_due": {
+          "name": "cards_due",
+          "columns": [
+            {
+              "expression": "due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cards_exercise_id_exercises_id_fk": {
+          "name": "cards_exercise_id_exercises_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deviations": {
+      "name": "deviations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repertoire_name_snapshot": {
+          "name": "repertoire_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_name_snapshot": {
+          "name": "chapter_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "deviation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_book_plies": {
+          "name": "in_book_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_plies": {
+          "name": "game_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played_san": {
+          "name": "played_san",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cp_loss": {
+          "name": "cp_loss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_category": {
+          "name": "engine_category",
+          "type": "engine_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drillable": {
+          "name": "drillable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deviations_game_repertoire": {
+          "name": "deviations_game_repertoire",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_repertoire_id": {
+          "name": "deviations_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_chapter_id": {
+          "name": "deviations_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deviations_game_id_games_id_fk": {
+          "name": "deviations_game_id_games_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deviations_repertoire_id_repertoires_id_fk": {
+          "name": "deviations_repertoire_id_repertoires_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deviations_chapter_id_repertoire_chapters_id_fk": {
+          "name": "deviations_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_responses": {
+      "name": "training_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "training_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "training_responses_exercise_id": {
+          "name": "training_responses_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_responses_exercise_id_exercises_id_fk": {
+          "name": "training_responses_exercise_id_exercises_id_fk",
+          "tableFrom": "training_responses",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_sources": {
+      "name": "exercise_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "drill_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviation_id": {
+          "name": "deviation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "exercise_sources_deviation": {
+          "name": "exercise_sources_deviation",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"deviation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_ply": {
+          "name": "exercise_sources_ply",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"game_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter": {
+          "name": "exercise_sources_chapter",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"chapter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_deviation_id": {
+          "name": "exercise_sources_deviation_id",
+          "columns": [
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_game_id": {
+          "name": "exercise_sources_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter_id": {
+          "name": "exercise_sources_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_sources_exercise_id_exercises_id_fk": {
+          "name": "exercise_sources_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_deviation_id_deviations_id_fk": {
+          "name": "exercise_sources_deviation_id_deviations_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "deviations",
+          "columnsFrom": ["deviation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_game_id_games_id_fk": {
+          "name": "exercise_sources_game_id_games_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_chapter_id_repertoire_chapters_id_fk": {
+          "name": "exercise_sources_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exercise_sources_origin_shape": {
+          "name": "exercise_sources_origin_shape",
+          "value": "(\"exercise_sources\".\"origin\" = 'repertoire-deviation'\n             AND \"exercise_sources\".\"deviation_id\" IS NOT NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'engine-blunder'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NOT NULL AND \"exercise_sources\".\"ply\" IS NOT NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'repertoire-line'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exercises_user_position": {
+          "name": "exercises_user_position",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_user_id": {
+          "name": "exercises_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_analyses": {
+      "name": "game_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine_version": {
+          "name": "engine_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "positions": {
+          "name": "positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_analyses_game_id": {
+          "name": "game_analyses_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_analyses_game_id_games_id_fk": {
+          "name": "game_analyses_game_id_games_id_fk",
+          "tableFrom": "game_analyses",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "game_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perspective": {
+          "name": "perspective",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "white_name": {
+          "name": "white_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "white_rating": {
+          "name": "white_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_name": {
+          "name": "black_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "black_rating": {
+          "name": "black_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "game_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_initial_seconds": {
+          "name": "time_control_initial_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_increment_seconds": {
+          "name": "time_control_increment_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_raw": {
+          "name": "time_control_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_eco": {
+          "name": "opening_eco",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_name": {
+          "name": "opening_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_url": {
+          "name": "opening_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination": {
+          "name": "termination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_clocks": {
+          "name": "has_clocks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_pgn": {
+          "name": "raw_pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movetext_hash": {
+          "name": "movetext_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "games_account_source_external_id": {
+          "name": "games_account_source_external_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"games\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_account_played_at": {
+          "name": "games_account_played_at",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_account_id_tracked_accounts_id_fk": {
+          "name": "games_account_id_tracked_accounts_id_fk",
+          "tableFrom": "games",
+          "tableTo": "tracked_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_account_movetext": {
+          "name": "games_account_movetext",
+          "nullsNotDistinct": true,
+          "columns": ["account_id", "movetext_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoire_chapters": {
+      "name": "repertoire_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn": {
+          "name": "pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting_fen": {
+          "name": "starting_fen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoire_chapters_repertoire_id": {
+          "name": "repertoire_chapters_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoire_chapters_repertoire_id_repertoires_id_fk": {
+          "name": "repertoire_chapters_repertoire_id_repertoires_id_fk",
+          "tableFrom": "repertoire_chapters",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repertoire_chapters_repertoire_sort": {
+          "name": "repertoire_chapters_repertoire_sort",
+          "nullsNotDistinct": false,
+          "columns": ["repertoire_id", "sort_order"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoires": {
+      "name": "repertoires",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "repertoire_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoires_user_id": {
+          "name": "repertoires_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoires_user_id_users_id_fk": {
+          "name": "repertoires_user_id_users_id_fk",
+          "tableFrom": "repertoires",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id": {
+          "name": "sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_accounts": {
+      "name": "tracked_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flair": {
+          "name": "flair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_accounts_user_platform_username": {
+          "name": "tracked_accounts_user_platform_username",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_accounts_user_id": {
+          "name": "tracked_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracked_accounts_user_id_users_id_fk": {
+          "name": "tracked_accounts_user_id_users_id_fk",
+          "tableFrom": "tracked_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier": {
+          "name": "verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.card_phase": {
+      "name": "card_phase",
+      "schema": "public",
+      "values": ["new", "learning", "review", "relearning"]
+    },
+    "public.deviation_type": {
+      "name": "deviation_type",
+      "schema": "public",
+      "values": ["deviation", "gap", "book-ended", "completed", "unmatched"]
+    },
+    "public.training_grade": {
+      "name": "training_grade",
+      "schema": "public",
+      "values": ["again", "hard", "good", "easy"]
+    },
+    "public.drill_origin": {
+      "name": "drill_origin",
+      "schema": "public",
+      "values": ["repertoire-deviation", "engine-blunder", "repertoire-line"]
+    },
+    "public.engine_category": {
+      "name": "engine_category",
+      "schema": "public",
+      "values": ["ok", "inaccuracy", "mistake", "blunder"]
+    },
+    "public.game_source": {
+      "name": "game_source",
+      "schema": "public",
+      "values": ["chess_com", "lichess", "pgn"]
+    },
+    "public.perspective": {
+      "name": "perspective",
+      "schema": "public",
+      "values": ["white", "black"]
+    },
+    "public.platform": {
+      "name": "platform",
+      "schema": "public",
+      "values": ["chess_com", "lichess"]
+    },
+    "public.repertoire_source": {
+      "name": "repertoire_source",
+      "schema": "public",
+      "values": ["manual", "extracted"]
+    },
+    "public.game_result": {
+      "name": "game_result",
+      "schema": "public",
+      "values": ["1-0", "0-1", "1/2-1/2", "*"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/migrations/meta/_journal.json
+++ b/libs/infra/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1787569610477,
       "tag": "0016_rate_limits",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1787606597509,
+      "tag": "0017_account_scoped_game_dedup",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/migrations/meta/_journal.json
+++ b/libs/infra/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1787494859474,
       "tag": "0015_profile_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1787569610477,
+      "tag": "0016_rate_limits",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/queries/drill.ts
+++ b/libs/infra/db/queries/drill.ts
@@ -188,14 +188,6 @@ export async function listExercisesByUser(db: Database, userId: string) {
   return db.select().from(exercises).where(eq(exercises.userId, userId));
 }
 
-export async function getExercise(db: Database, exerciseId: string) {
-  const [exercise] = await db
-    .select()
-    .from(exercises)
-    .where(eq(exercises.id, exerciseId));
-  return exercise ?? null;
-}
-
 /**
  * Scoped by owner — the HTTP shape. An answer writes a response row and
  * reschedules an FSRS card, so the exercise id in a request body is a

--- a/libs/infra/db/queries/rate-limit.ts
+++ b/libs/infra/db/queries/rate-limit.ts
@@ -1,0 +1,99 @@
+/**
+ * The API's rate limiter, as one atomic statement.
+ *
+ * Postgres is the arbiter rather than process memory, so the limit holds
+ * across however many API instances are running — an in-memory counter is
+ * per-instance and resets on deploy, which is a limit that lies.
+ *
+ * The window is not a fixed calendar minute, and that is deliberate: it
+ * copies Better Auth's semantics so the two limiters in this system behave
+ * the same way. `last_request` advances on every ALLOWED request and stays
+ * put while blocking, so the rule reads: at most `max` requests, then wait
+ * `window` from your last accepted one.
+ *
+ * One row per key, updated in place. The row count is bounded by the number
+ * of users, not by elapsed time, so there is nothing to prune — which is
+ * why this is not `(key, window_start)`.
+ */
+
+import { sql } from "drizzle-orm";
+
+import type { Database } from "../client.ts";
+
+export interface RateLimitPolicy {
+  /** Namespaces the key, so one user's budgets never share a counter. */
+  name: string;
+  max: number;
+  windowSeconds: number;
+}
+
+export interface RateLimitVerdict {
+  allowed: boolean;
+  /** Whole seconds until the window frees up. 0 when allowed. */
+  retryAfterSeconds: number;
+}
+
+interface Row {
+  count: number;
+  retry_after: number;
+}
+
+export async function consumeRateLimit(
+  db: Database,
+  subject: string,
+  policy: RateLimitPolicy,
+): Promise<RateLimitVerdict> {
+  const key = `${policy.name}:${subject}`;
+  // Bound as a parameter rather than interpolated into an interval literal:
+  // the value is ours today, and a query that cannot be made to lie is
+  // cheaper than remembering that it must not be.
+  const window = sql`make_interval(secs => ${policy.windowSeconds})`;
+
+  // A single statement so concurrent requests cannot all read a stale count
+  // before any increment lands. The CASE arms are, in order: the window
+  // expired (start over), there is budget left (spend it), or we are over
+  // the limit (touch nothing, so the wait is measured from the last
+  // request we actually accepted).
+  //
+  // The counter saturates at `max + 1`, one past the budget, and that extra
+  // step is what makes the verdict readable: a count that stopped AT `max`
+  // is indistinguishable from a request that just spent the last unit.
+  // `last_request` advances only on an accepted request, so a client that
+  // keeps hammering never extends its own lockout.
+  const result = await db.execute(sql`
+    INSERT INTO rate_limits AS r (key, count, last_request)
+    VALUES (${key}, 1, now())
+    ON CONFLICT (key) DO UPDATE SET
+      count = CASE
+        WHEN r.last_request < now() - ${window} THEN 1
+        WHEN r.count <= ${policy.max}           THEN r.count + 1
+        ELSE r.count
+      END,
+      last_request = CASE
+        WHEN r.last_request < now() - ${window} OR r.count < ${policy.max} THEN now()
+        ELSE r.last_request
+      END
+    RETURNING
+      count,
+      GREATEST(
+        0,
+        CEIL(EXTRACT(EPOCH FROM (last_request + ${window} - now())))
+      )::int AS retry_after
+  `);
+
+  // The drivers disagree on the shape of a raw result: postgres-js returns
+  // the rows themselves, PGlite returns `{ rows }`. Normalized here so the
+  // limiter behaves identically under the test database and under
+  // production's — a silent `undefined` would read as "allowed".
+  const rows = Array.isArray(result) ? result : (result as { rows: Row[] }).rows;
+  const row = (rows as Row[])[0] ?? { count: 1, retry_after: 0 };
+  const allowed = Number(row.count) <= policy.max;
+
+  return {
+    allowed,
+    // A blocked caller is told when the window frees up; an allowed one has
+    // nothing to wait for, and saying otherwise would invite a client to
+    // sleep for no reason.
+    retryAfterSeconds: allowed ? 0 : Math.max(1, Number(row.retry_after)),
+  };
+}

--- a/libs/infra/db/queries/rate-limit.ts
+++ b/libs/infra/db/queries/rate-limit.ts
@@ -19,6 +19,7 @@
 import { sql } from "drizzle-orm";
 
 import type { Database } from "../client.ts";
+import { rateLimits } from "../schema.ts";
 
 export interface RateLimitPolicy {
   /** Namespaces the key, so one user's budgets never share a counter. */
@@ -33,11 +34,6 @@ export interface RateLimitVerdict {
   retryAfterSeconds: number;
 }
 
-interface Row {
-  count: number;
-  retry_after: number;
-}
-
 export async function consumeRateLimit(
   db: Database,
   subject: string,
@@ -49,51 +45,55 @@ export async function consumeRateLimit(
   // cheaper than remembering that it must not be.
   const window = sql`make_interval(secs => ${policy.windowSeconds})`;
 
-  // A single statement so concurrent requests cannot all read a stale count
-  // before any increment lands. The CASE arms are, in order: the window
-  // expired (start over), there is budget left (spend it), or we are over
-  // the limit (touch nothing, so the wait is measured from the last
-  // request we actually accepted).
+  // The query builder, not db.execute(): its .returning() normalizes the
+  // row shape across drivers (postgres-js vs PGlite) on its own, which is
+  // the ORM's job, not this function's. Unqualified column references in
+  // the CASE arms below (rateLimits.count etc.) already mean "the row
+  // before this statement" — that's Postgres's ON CONFLICT DO UPDATE
+  // semantics, not something the query needs to alias for.
+  //
+  // The CASE arms are, in order: the window expired (start over), there is
+  // budget left (spend it), or we are over the limit (touch nothing, so the
+  // wait is measured from the last request we actually accepted).
   //
   // The counter saturates at `max + 1`, one past the budget, and that extra
   // step is what makes the verdict readable: a count that stopped AT `max`
   // is indistinguishable from a request that just spent the last unit.
   // `last_request` advances only on an accepted request, so a client that
   // keeps hammering never extends its own lockout.
-  const result = await db.execute(sql`
-    INSERT INTO rate_limits AS r (key, count, last_request)
-    VALUES (${key}, 1, now())
-    ON CONFLICT (key) DO UPDATE SET
-      count = CASE
-        WHEN r.last_request < now() - ${window} THEN 1
-        WHEN r.count <= ${policy.max}           THEN r.count + 1
-        ELSE r.count
-      END,
-      last_request = CASE
-        WHEN r.last_request < now() - ${window} OR r.count < ${policy.max} THEN now()
-        ELSE r.last_request
-      END
-    RETURNING
-      count,
-      GREATEST(
+  const [row] = await db
+    .insert(rateLimits)
+    .values({ key, count: 1, lastRequest: sql`now()` })
+    .onConflictDoUpdate({
+      target: rateLimits.key,
+      set: {
+        count: sql`CASE
+          WHEN ${rateLimits.lastRequest} < now() - ${window} THEN 1
+          WHEN ${rateLimits.count} <= ${policy.max}          THEN ${rateLimits.count} + 1
+          ELSE ${rateLimits.count}
+        END`,
+        lastRequest: sql`CASE
+          WHEN ${rateLimits.lastRequest} < now() - ${window} OR ${rateLimits.count} < ${policy.max}
+            THEN now()
+          ELSE ${rateLimits.lastRequest}
+        END`,
+      },
+    })
+    .returning({
+      count: rateLimits.count,
+      // A blocked caller is told when the window frees up; an allowed one
+      // has nothing to wait for, and saying otherwise would invite a
+      // client to sleep for no reason.
+      retryAfterSeconds: sql<number>`GREATEST(
         0,
-        CEIL(EXTRACT(EPOCH FROM (last_request + ${window} - now())))
-      )::int AS retry_after
-  `);
+        CEIL(EXTRACT(EPOCH FROM (${rateLimits.lastRequest} + ${window} - now())))
+      )::int`,
+    });
 
-  // The drivers disagree on the shape of a raw result: postgres-js returns
-  // the rows themselves, PGlite returns `{ rows }`. Normalized here so the
-  // limiter behaves identically under the test database and under
-  // production's — a silent `undefined` would read as "allowed".
-  const rows = Array.isArray(result) ? result : (result as { rows: Row[] }).rows;
-  const row = (rows as Row[])[0] ?? { count: 1, retry_after: 0 };
-  const allowed = Number(row.count) <= policy.max;
+  const allowed = row!.count <= policy.max;
 
   return {
     allowed,
-    // A blocked caller is told when the window frees up; an allowed one has
-    // nothing to wait for, and saying otherwise would invite a client to
-    // sleep for no reason.
-    retryAfterSeconds: allowed ? 0 : Math.max(1, Number(row.retry_after)),
+    retryAfterSeconds: allowed ? 0 : Math.max(1, row!.retryAfterSeconds),
   };
 }

--- a/libs/infra/db/schema.ts
+++ b/libs/infra/db/schema.ts
@@ -16,6 +16,7 @@ import {
 } from "@velachess/platforms/schema";
 import { sql } from "drizzle-orm";
 import {
+  bigint,
   bigserial,
   boolean,
   check,
@@ -160,6 +161,45 @@ export const verifications = pgTable(
   },
   (table) => [index("verifications_identifier").on(table.identifier)],
 );
+
+/**
+ * Better Auth's own rate-limit store, for `rateLimit.storage: "database"`.
+ *
+ * The shape is not ours to choose — it is what @better-auth/core declares in
+ * `db/get-tables.mjs` for the `rateLimit` model: `key` (unique string),
+ * `count` (number) and `lastRequest` (number, **bigint**, epoch millis, not a
+ * timestamp). Getting the type wrong here fails at runtime, inside the
+ * library, on the first throttled request — so it is written to match rather
+ * than to look like the rest of this file.
+ *
+ * One row per key, updated in place: Better Auth also prunes it itself
+ * (`deleteExpiredRows` inside its `consume`), so nothing here needs a
+ * cleanup job.
+ */
+export const authRateLimits = pgTable("auth_rate_limits", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  key: text("key").notNull().unique(),
+  count: integer("count").notNull(),
+  lastRequest: bigint("last_request", { mode: "number" }).notNull(),
+});
+
+/**
+ * The API's own rate limiter — separate from Better Auth's on purpose.
+ *
+ * Better Auth owns `/auth/*` and throttles it with its own table above;
+ * this one covers the authenticated application routes, keyed by user.
+ * Same storage shape deliberately: one row per key, updated in place, so
+ * the row count is bounded by users rather than by elapsed time and there
+ * is nothing to prune.
+ *
+ * `lastRequest` here IS a timestamp, unlike Better Auth's — this table is
+ * ours, and Postgres comparing intervals beats comparing epoch integers.
+ */
+export const rateLimits = pgTable("rate_limits", {
+  key: text("key").primaryKey(),
+  count: integer("count").notNull(),
+  lastRequest: timestamp("last_request", { withTimezone: true }).notNull(),
+});
 
 /**
  * A chess.com or Lichess handle this user follows.

--- a/libs/infra/db/schema.ts
+++ b/libs/infra/db/schema.ts
@@ -285,12 +285,13 @@ export const games = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("games_source_external_id")
-      .on(table.source, table.externalId)
+    // Both scoped to the tracked account: each account owns a complete,
+    // independent copy of whatever it imports, and dedup only ever
+    // happens within one account — never across two accounts tracking
+    // the same real provider handle.
+    uniqueIndex("games_account_source_external_id")
+      .on(table.accountId, table.source, table.externalId)
       .where(sql`${table.externalId} is not null`),
-    // One game = one row, keyed by whoever imports first. A game_accounts
-    // join table is the upgrade path if tracking both sides of the same
-    // game ever becomes real.
     unique("games_account_movetext")
       .on(table.accountId, table.movetextHash)
       .nullsNotDistinct(),

--- a/libs/ui/src/icons/brand.tsx
+++ b/libs/ui/src/icons/brand.tsx
@@ -43,11 +43,6 @@ export function LichessIcon(props: BrandIconProps) {
   );
 }
 
-/**
- * The monochrome "G", as shadcn's login block ships it — `currentColor`
- * like every other mark here. Google's branding also blesses a solid
- * single-colour G on outline buttons, so nothing is being bent.
- */
 export function GoogleIcon(props: BrandIconProps) {
   return (
     <BrandIcon {...props}>

--- a/libs/ui/src/icons/brand.tsx
+++ b/libs/ui/src/icons/brand.tsx
@@ -43,6 +43,44 @@ export function LichessIcon(props: BrandIconProps) {
   );
 }
 
+/**
+ * The one mark here that does NOT inherit `currentColor`.
+ *
+ * Google's sign-in branding guidelines allow the "G" only in its four
+ * official colours (or as a solid white/black variant on a matching
+ * button); a tinted G is a modified logo. So the fills are literal, and
+ * this component takes no colour from its surroundings.
+ */
+export function GoogleIcon({ title, ...props }: BrandIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      role={title ? "img" : "presentation"}
+      aria-hidden={title ? undefined : true}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      {title ? <title>{title}</title> : null}
+      <path
+        fill="#4285F4"
+        d="M23.52 12.273c0-.851-.076-1.669-.218-2.454H12v4.642h6.458a5.52 5.52 0 0 1-2.394 3.622v3.01h3.878c2.269-2.088 3.578-5.165 3.578-8.82Z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 24c3.24 0 5.956-1.075 7.942-2.907l-3.878-3.01c-1.075.72-2.45 1.145-4.064 1.145-3.125 0-5.77-2.11-6.714-4.947H1.276v3.109A11.995 11.995 0 0 0 12 24Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.286 14.281A7.207 7.207 0 0 1 4.91 12c0-.791.136-1.56.376-2.281V6.61H1.276A11.995 11.995 0 0 0 0 12c0 1.936.464 3.769 1.276 5.39l4.01-3.109Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 4.773c1.762 0 3.344.605 4.588 1.794l3.442-3.442C17.951 1.19 15.235 0 12 0 7.31 0 3.255 2.69 1.276 6.609l4.01 3.11C6.23 6.882 8.875 4.772 12 4.772Z"
+      />
+    </svg>
+  );
+}
+
 export function GitHubIcon(props: BrandIconProps) {
   return (
     <BrandIcon {...props}>

--- a/libs/ui/src/icons/brand.tsx
+++ b/libs/ui/src/icons/brand.tsx
@@ -44,40 +44,15 @@ export function LichessIcon(props: BrandIconProps) {
 }
 
 /**
- * The one mark here that does NOT inherit `currentColor`.
- *
- * Google's sign-in branding guidelines allow the "G" only in its four
- * official colours (or as a solid white/black variant on a matching
- * button); a tinted G is a modified logo. So the fills are literal, and
- * this component takes no colour from its surroundings.
+ * The monochrome "G", as shadcn's login block ships it — `currentColor`
+ * like every other mark here. Google's branding also blesses a solid
+ * single-colour G on outline buttons, so nothing is being bent.
  */
-export function GoogleIcon({ title, ...props }: BrandIconProps) {
+export function GoogleIcon(props: BrandIconProps) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      role={title ? "img" : "presentation"}
-      aria-hidden={title ? undefined : true}
-      xmlns="http://www.w3.org/2000/svg"
-      {...props}
-    >
-      {title ? <title>{title}</title> : null}
-      <path
-        fill="#4285F4"
-        d="M23.52 12.273c0-.851-.076-1.669-.218-2.454H12v4.642h6.458a5.52 5.52 0 0 1-2.394 3.622v3.01h3.878c2.269-2.088 3.578-5.165 3.578-8.82Z"
-      />
-      <path
-        fill="#34A853"
-        d="M12 24c3.24 0 5.956-1.075 7.942-2.907l-3.878-3.01c-1.075.72-2.45 1.145-4.064 1.145-3.125 0-5.77-2.11-6.714-4.947H1.276v3.109A11.995 11.995 0 0 0 12 24Z"
-      />
-      <path
-        fill="#FBBC05"
-        d="M5.286 14.281A7.207 7.207 0 0 1 4.91 12c0-.791.136-1.56.376-2.281V6.61H1.276A11.995 11.995 0 0 0 0 12c0 1.936.464 3.769 1.276 5.39l4.01-3.109Z"
-      />
-      <path
-        fill="#EA4335"
-        d="M12 4.773c1.762 0 3.344.605 4.588 1.794l3.442-3.442C17.951 1.19 15.235 0 12 0 7.31 0 3.255 2.69 1.276 6.609l4.01 3.11C6.23 6.882 8.875 4.772 12 4.772Z"
-      />
-    </svg>
+    <BrandIcon {...props}>
+      <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
+    </BrandIcon>
   );
 }
 

--- a/libs/ui/src/icons/index.ts
+++ b/libs/ui/src/icons/index.ts
@@ -4,5 +4,11 @@
  */
 export * from "lucide-react";
 
-export { ChessComIcon, GitHubIcon, LichessIcon, type BrandIconProps } from "./brand.tsx";
+export {
+  ChessComIcon,
+  GitHubIcon,
+  GoogleIcon,
+  LichessIcon,
+  type BrandIconProps,
+} from "./brand.tsx";
 export { VelaChessMark, type VelaChessMarkProps } from "./mark.tsx";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.5)(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.23.0)(postgres@3.4.9)
+      envalid:
+        specifier: ^8.2.0
+        version: 8.2.0
 
   libs/infra/db:
     dependencies:
@@ -4167,6 +4170,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  envalid@8.2.0:
+    resolution: {integrity: sha512-CkPvea95dwMYE1wnKX5mQXkOpiMs9O+ncv8NqZy+gW7FuzpUp06KTdUHb18xFG8CqQHmfmRqGLF5DuGaBWNrSw==}
+    engines: {node: '>=18'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -9928,6 +9935,10 @@ snapshots:
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
+
+  envalid@8.2.0:
+    dependencies:
+      tslib: 2.8.1
 
   error-ex@1.3.4:
     dependencies:


### PR DESCRIPTION
## What

Google sign-in via Better Auth, API rate limiting, and Settings → Account, plus a fix pass over all of it (account-linking, sync limits, edge-comment accuracy, typed error contract). Closes #18.

## Why

Self-host needed a way in besides the one bootstrap password user, and the API needed real rate limiting once it's reachable publicly.

## How

- Google OAuth through Better Auth; `redirectURI` pinned to `/api/auth/callback/google` so the return leg reuses the existing `/api/*` proxy, no second reverse-proxy rule
- bootstrap-created accounts are marked `emailVerified` at creation, so Google can link to them on the same email — otherwise permanently blocked
- two rate limiters: Better Auth's own on `/auth/*`, an app-level one (`libs/infra/db/queries/rate-limit.ts`) on the rest — `import` is keyed by `(userId, accountId)`, not just `userId`, so tracking several accounts doesn't throttle the first ones
- `AppType` now runs through `ApplyGlobalResponse` so 401/403/404/413/429/500 — none of which sit in any route's own handler chain — are part of the typed `hc<AppType>` contract
- `cors()`/`csrf()` comments corrected to match hono's actual behavior, verified against the installed `hono@4.13.2` source

## Verification

`pnpm check` and `pnpm test` (full monorepo suite) green.

## Evidence

- API — rejected sign-in and a 429 carry the same shape the client reads:
  ```
  $ curl -X POST localhost:3000/auth/sign-in/email -d '{"email":"x","password":"wrong"}'
  {"message":"Invalid email or password","code":"INVALID_EMAIL_OR_PASSWORD"}
  ```
- Frontend: sign-in screen, Settings → Account, and every OAuth failure/edge case covered by `apps/web/src/auth/__tests__/*`.

## Checklist

- [x] Tests added or updated
- [x] Relevant evidence included
- [ ] Migrations verified, if applicable
- [x] Documentation updated, if applicable
