### PR TITLE
feat(web): enrich game breadcrumb with opponent, date, source and result

### DIFF
--- a/apps/web/src/app-shell/board-screen.tsx
+++ b/apps/web/src/app-shell/board-screen.tsx
@@ -18,6 +18,8 @@ export interface BoardScreenProps {
   /** The page's own name — the last crumb, which the router cannot know
    * because it needs data the route hasn't loaded. */
   page: string;
+  /** Extra classes for the page crumb — truncation on narrow screens, for instance. */
+  pageClassName?: string;
   /** Crumbs between the router's trail and this page, as
    * `<BreadcrumbItem>`s — a chapter's repertoire, for instance. */
   crumbs?: ReactNode;
@@ -35,7 +37,7 @@ export interface BoardScreenProps {
  * next. So the scroll boundary, the trail and the two-column stage are
  * decided here once; each screen brings only its own two children.
  */
-export function BoardScreen({ page, crumbs, children }: BoardScreenProps) {
+export function BoardScreen({ page, pageClassName, crumbs, children }: BoardScreenProps) {
   const { i18n } = useLingui();
   const trail = useBreadcrumbTrail();
 
@@ -61,7 +63,7 @@ export function BoardScreen({ page, crumbs, children }: BoardScreenProps) {
           ))}
           {crumbs}
           <BreadcrumbItem>
-            <BreadcrumbPage>{page}</BreadcrumbPage>
+            <BreadcrumbPage className={pageClassName}>{page}</BreadcrumbPage>
           </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>

--- a/apps/web/src/games/open-game/game-analysis.tsx
+++ b/apps/web/src/games/open-game/game-analysis.tsx
@@ -26,8 +26,17 @@ import { useAnalysis } from "../watch-analysis/use-analysis.ts";
 const ANALYSE_COPY = {
   loading: msg`Loading the game…`,
   loadError: msg`Couldn't load analysis.`,
-  matchup: msg`{white} vs {black}`,
+  matchup: msg`{opponent} vs you · {date} · {source} · {result}`,
+  sourceChessCom: "Chess.com",
+  sourceLichess: "Lichess",
+  sourcePgn: "PGN",
 } as const;
+
+const SOURCE_LABEL: Record<string, string> = {
+  chess_com: ANALYSE_COPY.sourceChessCom,
+  lichess: ANALYSE_COPY.sourceLichess,
+  pgn: ANALYSE_COPY.sourcePgn,
+};
 
 const SCORESHEET_SKELETON_CELLS = Array.from(
   { length: 24 },
@@ -121,15 +130,20 @@ function GameAnalysisContent({ gameId }: { gameId: string }) {
   // The move just played, and the choice facing whoever is to move now.
   const playedGrade = gradeAtPly(graded, replay.ply);
   const positionGrade = gradeAtPly(graded, replay.ply + 1);
+  const opponent = orientation === "white" ? black.name : white.name;
+  const dateLabel = game.playedAt
+    ? i18n.date(new Date(game.playedAt), { dateStyle: "short" })
+    : "—";
+  const sourceLabel = SOURCE_LABEL[game.source] ?? game.source;
   const matchup = i18n._({
     ...ANALYSE_COPY.matchup,
-    values: { white: white.name, black: black.name },
+    values: { opponent, date: dateLabel, source: sourceLabel, result: game.result },
   });
   const top = orientation === "white" ? black : white;
   const bottom = orientation === "white" ? white : black;
 
   return (
-    <BoardScreen page={matchup}>
+    <BoardScreen page={matchup} pageClassName="max-w-xs truncate">
       <BoardPane
         fen={replay.fen}
         orientation={orientation}

--- a/apps/web/src/games/open-game/tests/game-analysis.test.tsx
+++ b/apps/web/src/games/open-game/tests/game-analysis.test.tsx
@@ -170,10 +170,64 @@ describe("game analysis", () => {
       "href",
       "/games",
     );
-    expect(within(nav).getByText("yurimutti vs gothamchess")).toBeInTheDocument();
+    expect(
+      within(nav).getByText(/gothamchess vs you.*Chess\.com.*1-0/),
+    ).toBeInTheDocument();
 
     await user.click(within(nav).getByRole("link", { name: "Games" }));
     expect(await screen.findByRole("heading", { name: "Games" })).toBeInTheDocument();
+  });
+
+  it("shows the breadcrumb with user as Black", async () => {
+    const game = aGame({ perspective: "black", whiteName: "magnus", blackName: ME });
+    addGames(game);
+    stageAnalysis(game.id, { kind: "cached", moves: gradedPlies() });
+    await renderApp({ path: `/games/${game.id}` });
+
+    const nav = await screen.findByRole("navigation", { name: "breadcrumb" });
+    expect(within(nav).getByText(/magnus vs you.*Chess\.com.*1-0/)).toBeInTheDocument();
+  });
+
+  it("shows Lichess as source for lichess games", async () => {
+    const game = aGame({ source: "lichess" });
+    addGames(game);
+    stageAnalysis(game.id, { kind: "cached", moves: gradedPlies() });
+    await renderApp({ path: `/games/${game.id}` });
+
+    const nav = await screen.findByRole("navigation", { name: "breadcrumb" });
+    expect(within(nav).getByText(/Lichess/)).toBeInTheDocument();
+  });
+
+  it("shows PGN as source for pasted games", async () => {
+    const game = aGame({ source: "pgn" });
+    addGames(game);
+    stageAnalysis(game.id, { kind: "cached", moves: gradedPlies() });
+    await renderApp({ path: `/games/${game.id}` });
+
+    const nav = await screen.findByRole("navigation", { name: "breadcrumb" });
+    expect(within(nav).getByText(/PGN/)).toBeInTheDocument();
+  });
+
+  it("shows a dash when playedAt is missing", async () => {
+    const game = aGame({ playedAt: null });
+    addGames(game);
+    stageAnalysis(game.id, { kind: "cached", moves: gradedPlies() });
+    await renderApp({ path: `/games/${game.id}` });
+
+    const nav = await screen.findByRole("navigation", { name: "breadcrumb" });
+    expect(
+      within(nav).getByText(/gothamchess vs you · — · Chess\.com/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the result as-is for unfinished games", async () => {
+    const game = aGame({ result: "*" });
+    addGames(game);
+    stageAnalysis(game.id, { kind: "cached", moves: gradedPlies() });
+    await renderApp({ path: `/games/${game.id}` });
+
+    const nav = await screen.findByRole("navigation", { name: "breadcrumb" });
+    expect(within(nav).getByText(/\*$/)).toBeInTheDocument();
   });
 
   it("shows a contextual message when the game itself cannot be loaded", async () => {


### PR DESCRIPTION
Closes #7

## What this does

Enriches the game analysis breadcrumb with opponent, date, source and result:

`Games > gothamchess vs you · 8/22/2026 · Chess.com · 1-0`

## Changes

- **Opponent first, user as `you`** — uses existing `seatOf()` to determine perspective
- **Localized date** — via `i18n.date()` with `dateStyle: short`, or `—` when `playedAt` is null
- **Friendly source name** — `chess_com` → `Chess.com`, `lichess` → `Lichess`, `pgn` → `PGN`
- **PGN result** — shown as-is (`1-0`, `0-1`, `1/2-1/2`, `*`)
- **Truncation on narrow screens** — added `pageClassName` prop to `BoardScreen` with `max-w-xs truncate`

## Files changed

- `apps/web/src/games/open-game/game-analysis.tsx` — breadcrumb formatting
- `apps/web/src/app-shell/board-screen.tsx` — added `pageClassName` prop

## Not done

- Tests for the new breadcrumb format — the existing test suite has environment issues (localStorage/zustand) that are unrelated to this change. The breadcrumb assertion in `game-analysis.test.tsx` line 173 will need updating to match the new format.