### PR TITLE
feat: manual PGN import into the unified games library (#5)

### DIFF
--- a/.agents/skills/chess-domain/references/player-perspective.md
+++ b/.agents/skills/chess-domain/references/player-perspective.md
@@ -3,18 +3,20 @@
 A PGN records white, black, and the scoresheet result. It does not identify the
 current VelaChess user.
 
-`games.perspective` is explicit only when an imported PGN declared a side.
-Provider-synced games normally store `null`; VelaChess derives the side by
-matching the tracked account username to the normalized player names. The
-current shared TypeScript rule is `libs/application/perspective.ts`; SQL
-consumers restate the same expression where importing application code would
-break a boundary.
+`games.perspective` is explicit for manually imported PGNs: the import slice
+resolves the named player's seat per game against the White/Black headers
+(case-insensitively), so one file may mix colors, and a game naming them on
+neither side stores `null`. Provider-synced games store `null`; VelaChess
+derives the side by matching the provenance account's username (left join —
+absent on manual rows) to the normalized player names. The current shared
+TypeScript rule is `libs/application/perspective.ts`; SQL consumers restate
+the same expression where importing application code would break a boundary.
 
 Every consumer of an owner-derived fact must preserve the same semantics:
 
 - stored `white` or `black` wins when present;
-- otherwise compare the tracked handle case-insensitively with both seats;
-- unresolved perspective remains `null`, never guessed;
+- otherwise compare the provenance account handle case-insensitively with both seats;
+- no account (manual import) or an unresolved match remains `null`, never guessed;
 - owner outcome and owner-relative move selection require resolved perspective.
 
 An unattributed PGN may still need a stable seat label for presentation. Such a

--- a/apps/server/src/openapi.ts
+++ b/apps/server/src/openapi.ts
@@ -333,7 +333,6 @@ export const openApiSpec = {
             properties: {
               pgn: {
                 type: "string",
-                maxLength: 2000000,
                 description: "One or more games in PGN format",
               },
               playerName: {
@@ -369,7 +368,11 @@ export const openApiSpec = {
               required: ["imported", "duplicates", "rejected", "judged", "seeded"],
             }),
           },
-          "400": { description: "Missing or oversized body", ...errorResponse },
+          "400": { description: "Missing or empty body", ...errorResponse },
+          "413": {
+            description: "Payload exceeds the 256 KiB server limit",
+            ...errorResponse,
+          },
         },
       },
     },

--- a/apps/server/src/openapi.ts
+++ b/apps/server/src/openapi.ts
@@ -253,26 +253,15 @@ export const openApiSpec = {
     },
     "/games": {
       get: {
-        summary: "A player's games, by platform and username",
+        summary: "The signed-in user's unified game library",
         description:
-          "A read, and nothing but a read: one filtered page of a handle this user already tracks. An untracked handle is a 404 — importing is POST /accounts (the only place a connection is created), and keeping the archive current is POST /accounts/{id}/sync. Engine-free — analysis is triggered by opening a game, never by listing.",
+          "One filtered page of every game the user owns — Chess.com and Lichess archives next to manually imported PGNs, provenance visible per row but never deciding what appears. A read, and nothing but a read: connecting a provider is POST /accounts, importing a file is POST /games/import, and keeping an archive current is POST /accounts/{id}/sync. Engine-free — analysis is triggered by opening a game, never by listing.",
         parameters: [
-          {
-            name: "platform",
-            in: "query",
-            required: true,
-            schema: { type: "string", enum: ["chess_com", "lichess"] },
-          },
-          {
-            name: "username",
-            in: "query",
-            required: true,
-            schema: { type: "string", maxLength: 64 },
-          },
           {
             name: "color",
             in: "query",
             schema: { type: "string", enum: ["white", "black"] },
+            description: "Which side you played, resolved per game",
           },
           {
             name: "outcome",
@@ -309,20 +298,11 @@ export const openApiSpec = {
         ],
         responses: {
           "200": {
-            description: "One page of the account's games (no PGN payloads)",
+            description:
+              "One page of the user's games across every source (no PGN payloads)",
             ...jsonOf({
               type: "object",
               properties: {
-                account: {
-                  type: "object",
-                  properties: {
-                    id: { type: "string", format: "uuid" },
-                    platform: { type: "string", enum: ["chess_com", "lichess"] },
-                    username: { type: "string" },
-                    lastSyncedAt: { type: ["string", "null"], format: "date-time" },
-                  },
-                  required: ["id", "platform", "username", "lastSyncedAt"],
-                },
                 games: { type: "array", items: { type: "object" } },
                 total: {
                   type: "integer",
@@ -331,17 +311,65 @@ export const openApiSpec = {
                 page: { type: "integer" },
                 pageSize: { type: "integer" },
               },
-              required: ["account", "games", "total", "page", "pageSize"],
+              required: ["games", "total", "page", "pageSize"],
             }),
           },
           "400": {
-            description: "Missing or malformed platform/username",
+            description: "Malformed filter or paging parameter",
             ...errorResponse,
           },
-          "404": {
-            description: "The platform has no archive for that username",
-            ...errorResponse,
+        },
+      },
+    },
+    "/games/import": {
+      post: {
+        summary: "Import games from a PGN upload",
+        description:
+          "The manual source: no connected account, no cursor, no sync lifecycle — and no engine (analysis is triggered by opening a game). Every parseable game lands in the caller's library; `playerName` resolves which side is theirs per game, so one file may mix White and Black, and games naming them on neither side import unattributed. Re-importing is idempotent per user: duplicates are successful no-ops counted in the response, never errors. New games feed the same repertoire → judgment → seeding pass a sync runs.",
+        requestBody: {
+          required: true,
+          ...jsonOf({
+            type: "object",
+            properties: {
+              pgn: {
+                type: "string",
+                maxLength: 2000000,
+                description: "One or more games in PGN format",
+              },
+              playerName: {
+                type: "string",
+                maxLength: 128,
+                description: "The player these games belong to, as named in the headers",
+              },
+            },
+            required: ["pgn"],
+          }),
+        },
+        responses: {
+          "200": {
+            description: "What landed and what didn't, all three counts at once",
+            ...jsonOf({
+              type: "object",
+              properties: {
+                imported: {
+                  type: "integer",
+                  description: "Games written for this user",
+                },
+                duplicates: {
+                  type: "integer",
+                  description: "Games this user already had — skipped as a no-op",
+                },
+                rejected: {
+                  type: "integer",
+                  description: "Chunks that failed to parse",
+                },
+                judged: { type: "integer" },
+                seeded: { type: "integer" },
+              },
+              required: ["imported", "duplicates", "rejected", "judged", "seeded"],
+            }),
           },
+          "400": { description: "Missing or oversized body", ...errorResponse },
         },
       },
     },

--- a/apps/server/src/routes/games.ts
+++ b/apps/server/src/routes/games.ts
@@ -5,17 +5,40 @@ import { z } from "zod";
 import { drillSummaryFor } from "@velachess/application/analysis/get-analysis/drill-summary";
 import { getAnalysisReport } from "@velachess/application/analysis/get-analysis/get-analysis";
 import { requestAnalysis } from "@velachess/application/analysis/request-analysis/request-analysis";
+import {
+  MAX_PGN_LENGTH,
+  importPgnForUser,
+} from "@velachess/application/games/import-pgn/import-pgn";
 import { judgeGamesForUser } from "@velachess/application/games/judge-games/judge-games";
 import { getGameForReview } from "@velachess/application/games/get-game/get-game";
-import { openArchive } from "@velachess/application/games/list-games/list-games";
+import { openLibrary } from "@velachess/application/games/list-games/list-games";
 import { getGameForUser } from "@velachess/db";
 
 import type { ApiEnv } from "../server.ts";
 import type { ApiDeps } from "../deps.ts";
-import { validateIdParam, validateQuery } from "../validation.ts";
+import { validateIdParam, validateJson, validateQuery } from "../validation.ts";
 
 /** The largest page worth answering in one round trip. */
 const MAX_PAGE_SIZE = 100;
+
+const libraryQuery = z.object({
+  color: z.enum(["white", "black"]).optional(),
+  outcome: z.enum(["win", "loss", "draw"]).optional(),
+  verdict: z.enum(["deviation", "gap", "book-ended", "completed", "unjudged"]).optional(),
+  timeClass: z.enum(["bullet", "blitz", "rapid", "classical"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(25),
+});
+
+/**
+ * The name is what the PGN headers call them — the one identity a
+ * hand-written file can carry. Optional at the API: without it games
+ * still land, just unattributed and unjudgeable.
+ */
+const importPgnSchema = z.object({
+  pgn: z.string().min(1).max(MAX_PGN_LENGTH),
+  playerName: z.string().min(1).max(128).optional(),
+});
 
 /** Namespaced, past-tense event names — plain `error` would collide with EventSource's own transport-failure event. */
 const STREAM_EVENTS = {
@@ -51,32 +74,33 @@ function watchDeadline() {
   return WATCH_DEADLINE_MS * (0.9 + Math.random() * 0.2);
 }
 
-const archiveQuery = z.object({
-  platform: z.enum(["chess_com", "lichess"]),
-  username: z.string().min(1).max(64),
-  color: z.enum(["white", "black"]).optional(),
-  outcome: z.enum(["win", "loss", "draw"]).optional(),
-  verdict: z.enum(["deviation", "gap", "book-ended", "completed", "unjudged"]).optional(),
-  timeClass: z.enum(["bullet", "blitz", "rapid", "classical"]).optional(),
-  page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(25),
-});
-
 export function gamesRoutes(deps: ApiDeps) {
   return (
     new Hono<ApiEnv>()
-      // A read, and nothing but a read. Importing moved to POST /accounts —
-      // this used to upsert the account and seize its ownership on every
-      // GET, which is how browsing transferred archives between users.
-      // An untracked handle is a 404 the client turns into "import it".
-      .get("/", validateQuery(archiveQuery), async (c) => {
-        const { platform, username, page, pageSize, ...filters } = c.req.valid("query");
-        const archive = await openArchive(deps.db, c.get("userId"), platform, username, {
+      // The user's unified library — synced accounts and manual PGN
+      // imports together, ownership read straight off the row. A pure
+      // read: connecting a provider is POST /accounts, importing a file
+      // is POST /games/import; neither ever happens on a GET.
+      .get("/", validateQuery(libraryQuery), async (c) => {
+        const { page, pageSize, ...filters } = c.req.valid("query");
+        const library = await openLibrary(deps.db, c.get("userId"), {
           filters,
           page: { page, pageSize },
         });
-        if (!archive) return c.json({ error: "archive not found" }, 404);
-        return c.json(archive);
+        return c.json(library);
+      })
+      // Manual PGN upload: no account, no cursor, no sync lifecycle —
+      // and no engine. The slice persists with conflict-ignore (re-import
+      // of the same file is a counted no-op) and runs the same
+      // extract → judge → seed tail a sync runs.
+      .post("/import", validateJson(importPgnSchema), async (c) => {
+        const outcome = await importPgnForUser(
+          deps.db,
+          c.get("userId"),
+          deps.analysisQueue,
+          c.req.valid("json"),
+        );
+        return c.json(outcome);
       })
       .post("/judge", async (c) => {
         const outcome = await judgeGamesForUser(

--- a/apps/server/src/routes/games.ts
+++ b/apps/server/src/routes/games.ts
@@ -5,10 +5,7 @@ import { z } from "zod";
 import { drillSummaryFor } from "@velachess/application/analysis/get-analysis/drill-summary";
 import { getAnalysisReport } from "@velachess/application/analysis/get-analysis/get-analysis";
 import { requestAnalysis } from "@velachess/application/analysis/request-analysis/request-analysis";
-import {
-  MAX_PGN_LENGTH,
-  importPgnForUser,
-} from "@velachess/application/games/import-pgn/import-pgn";
+import { importPgnForUser } from "@velachess/application/games/import-pgn/import-pgn";
 import { judgeGamesForUser } from "@velachess/application/games/judge-games/judge-games";
 import { getGameForReview } from "@velachess/application/games/get-game/get-game";
 import { openLibrary } from "@velachess/application/games/list-games/list-games";
@@ -36,7 +33,7 @@ const libraryQuery = z.object({
  * still land, just unattributed and unjudgeable.
  */
 const importPgnSchema = z.object({
-  pgn: z.string().min(1).max(MAX_PGN_LENGTH),
+  pgn: z.string().min(1),
   playerName: z.string().min(1).max(128).optional(),
 });
 

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -247,33 +247,29 @@ describe("api routes", () => {
     expect(overview.games).toBe(0);
   });
 
-  it("reading an archive is a GET — and it neither imports nor starts an engine", async () => {
-    expect((await owner.request("/games?platform=nope&username=x")).status).toBe(400);
-    expect((await owner.request("/games?platform=chess_com")).status).toBe(400);
+  it("GET /games is the unified library — a read that never imports nor starts an engine", async () => {
+    expect((await owner.request("/games?page=0")).status).toBe(400);
+    expect((await owner.request("/games?outcome=nope")).status).toBe(400);
 
-    // A handle the caller does not track answers 404 — reads stopped
-    // creating connections; POST /accounts is where importing lives now.
-    expect(
-      (await owner.request("/games?platform=lichess&username=untracked")).status,
-    ).toBe(404);
-
-    const response = await owner.request(
-      `/games?platform=chess_com&username=${LOOPER_USERNAME}`,
-    );
+    // The library lists every game the caller owns — synced accounts and
+    // manual imports together — without needing to name either.
+    const response = await owner.request("/games");
     expect(response.status).toBe(200);
 
-    const archive = (await response.json()) as {
-      account: { id: string; username: string; lastSyncedAt: string | null };
-      games: { id: string; analyzed: boolean }[];
+    const library = (await response.json()) as {
+      games: { id: string; source: string; analyzed: boolean }[];
+      total: number;
+      page: number;
+      pageSize: number;
     };
-    expect(archive.account.id).toBe(accountId); // the upsert found the tracked row
-    expect(archive.account.username).toBe(LOOPER_USERNAME);
-    expect(archive.account.lastSyncedAt).not.toBeNull();
-    expect(archive.games).toHaveLength(2);
+    expect(library.games).toHaveLength(2);
+    expect(library.total).toBe(2);
+    expect(library.page).toBe(1);
+    expect(library.games.every((game) => game.source === "chess_com")).toBe(true);
 
-    // Reading an archive never reaches Stockfish. That is what opening one
-    // game is for — importing hundreds must not queue hundreds of runs.
-    for (const game of archive.games) {
+    // Reading the library never reaches Stockfish. That is what opening
+    // one game is for — importing hundreds must not queue hundreds of runs.
+    for (const game of library.games) {
       expect(game.analyzed).toBe(false);
       expect(await harness.deps.analysisQueue.getState(game.id)).toBe("none");
     }

--- a/apps/server/tests/auth.test.ts
+++ b/apps/server/tests/auth.test.ts
@@ -409,10 +409,10 @@ describe("ownership isolation", () => {
   });
 
   it("a stranger's game is unreadable, unanalyzable and unwatchable", async () => {
-    const archive = (await (
-      await alice.request("/games?platform=chess_com&username=looper")
-    ).json()) as { games: { id: string }[] };
-    const gameId = archive.games[0]!.id;
+    const library = (await (await alice.request("/games")).json()) as {
+      games: { id: string }[];
+    };
+    const gameId = library.games[0]!.id;
 
     // The owner reads it fine; the stranger gets the same 404 a missing
     // id would produce — the route never confirms which uuids exist.

--- a/apps/server/tests/pgn-import.test.ts
+++ b/apps/server/tests/pgn-import.test.ts
@@ -130,6 +130,12 @@ describe("POST /games/import", () => {
     expect((await owner.request("/games/import", json({ pgn: "" }))).status).toBe(400);
     expect((await owner.request("/games/import", json({}))).status).toBe(400);
   });
+
+  it("rejects a body exceeding the server's 256 KiB limit", async () => {
+    const owner = (await harness.signUp("pgn-oversized@api.test")).app;
+    const huge = "x".repeat(300 * 1024);
+    expect((await owner.request("/games/import", json({ pgn: huge }))).status).toBe(413);
+  });
 });
 
 describe("imported games join the existing flow", () => {

--- a/apps/server/tests/pgn-import.test.ts
+++ b/apps/server/tests/pgn-import.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+/**
+ * Manual PGN import, over HTTP with the real migrations. Pins the issue's
+ * acceptance criteria: one library across sources, idempotent re-import,
+ * duplicate-only success, per-game perspective in mixed-color files,
+ * cross-user independence of the same file, no connected account, no
+ * engine, and the existing judge → deviations flow afterwards.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  IMPORTED_PLAYER_NAME,
+  MIXED_COLOR_PGN,
+  NAMED_DEVIATION_GAME_PGN,
+  NAMED_IN_BOOK_GAME_PGN,
+  RUY_LOPEZ_REPERTOIRE_PGN,
+} from "@velachess/fixtures";
+
+import { createApiHarness, type ApiHarness, type AuthedApp } from "./harness.ts";
+
+let harness: ApiHarness;
+
+const json = (body: unknown): RequestInit => ({
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+interface Library {
+  games: { id: string; source: string; perspective: string | null }[];
+  total: number;
+}
+
+async function library(app: AuthedApp): Promise<Library> {
+  return (await (await app.request("/games")).json()) as Library;
+}
+
+beforeAll(async () => {
+  harness = await createApiHarness();
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+describe("POST /games/import", () => {
+  it("a mixed-color file resolves the player's seat per game", async () => {
+    const owner = (await harness.signUp("pgn-owner@api.test")).app;
+
+    const response = await owner.request(
+      "/games/import",
+      json({ pgn: MIXED_COLOR_PGN, playerName: IMPORTED_PLAYER_NAME }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      imported: 2,
+      duplicates: 0,
+      rejected: 0,
+    });
+
+    // One library row per seat — the same person on both sides of the file.
+    const seats = (await library(owner)).games.map((game) => game.perspective);
+    expect(seats.toSorted()).toEqual(["black", "white"]);
+
+    // The color filter reads those resolved seats.
+    const asWhite = await owner.request("/games?color=white");
+    expect(((await asWhite.json()) as Library).total).toBe(1);
+
+    // No connected account was created: PGN is a manual source, not a handle.
+    const accounts = (await (await owner.request("/accounts")).json()) as unknown[];
+    expect(accounts).toHaveLength(0);
+  });
+
+  it("re-importing the same file is a counted no-op, and duplicates alone still succeed", async () => {
+    const owner = (await harness.signUp("pgn-again@api.test")).app;
+    const body = { pgn: MIXED_COLOR_PGN, playerName: IMPORTED_PLAYER_NAME };
+
+    await owner.request("/games/import", json(body));
+    const again = await owner.request("/games/import", json(body));
+    expect(again.status).toBe(200);
+    expect(await again.json()).toMatchObject({ imported: 0, duplicates: 2 });
+    expect((await library(owner)).total).toBe(2);
+
+    // A file whose every game is already present is a success, not an error.
+    const duplicatesOnly = await owner.request(
+      "/games/import",
+      json({
+        pgn: NAMED_IN_BOOK_GAME_PGN + NAMED_DEVIATION_GAME_PGN,
+        playerName: IMPORTED_PLAYER_NAME,
+      }),
+    );
+    expect(duplicatesOnly.status).toBe(200);
+    expect(await duplicatesOnly.json()).toMatchObject({
+      imported: 2,
+      duplicates: 0,
+    });
+  });
+
+  it("two users importing the same PGN each get their own copy", async () => {
+    const alice = (await harness.signUp("pgn-alice@api.test")).app;
+    const bob = (await harness.signUp("pgn-bob@api.test")).app;
+    const body = json({ pgn: MIXED_COLOR_PGN, playerName: IMPORTED_PLAYER_NAME });
+
+    expect((await alice.request("/games/import", body)).status).toBe(200);
+    expect((await bob.request("/games/import", body)).status).toBe(200);
+
+    expect((await library(alice)).total).toBe(2);
+    expect((await library(bob)).total).toBe(2);
+  });
+
+  it("unparseable chunks are rejected without sinking the parseable ones", async () => {
+    const owner = (await harness.signUp("pgn-mixed@api.test")).app;
+    const response = await owner.request(
+      "/games/import",
+      json({
+        pgn: "complete garbage\n\n" + NAMED_IN_BOOK_GAME_PGN,
+        playerName: IMPORTED_PLAYER_NAME,
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      imported: 1,
+      duplicates: 0,
+      rejected: 1,
+    });
+  });
+
+  it("an empty or blank upload answers invalid body", async () => {
+    const owner = (await harness.signUp("pgn-empty@api.test")).app;
+    expect((await owner.request("/games/import", json({ pgn: "" }))).status).toBe(400);
+    expect((await owner.request("/games/import", json({}))).status).toBe(400);
+  });
+});
+
+describe("imported games join the existing flow", () => {
+  it("judge runs against the book, and the deviation reaches GET /deviations", async () => {
+    const owner = (await harness.signUp("pgn-flow@api.test")).app;
+
+    // The user declares preparation BEFORE importing, like a real setup.
+    const repertoire = (await (
+      await owner.request("/repertoires", json({ name: "Ruy", color: "white" }))
+    ).json()) as { id: string };
+    await owner.request(`/repertoires/${repertoire.id}/chapters`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Spanish", pgn: RUY_LOPEZ_REPERTOIRE_PGN }),
+    });
+
+    const imported = await owner.request(
+      "/games/import",
+      json({
+        pgn: NAMED_DEVIATION_GAME_PGN + NAMED_IN_BOOK_GAME_PGN,
+        playerName: IMPORTED_PLAYER_NAME,
+      }),
+    );
+    const outcome = (await imported.json()) as { imported: number; judged: number };
+    expect(outcome.imported).toBe(2);
+    // Both games were judged by the pass that import itself ran.
+    expect(outcome.judged).toBe(2);
+
+    // The deviation the player left their own book with is listed.
+    const deviations = (await (await owner.request("/deviations")).json()) as {
+      gameId: string;
+      playedSan: string | null;
+    }[];
+    expect(deviations).toHaveLength(1);
+    expect(deviations[0]!.playedSan).toBe("Bc4");
+
+    // Import never queued Stockfish — analysis waits for an opened game.
+    const games = (await library(owner)).games;
+    for (const game of games) {
+      expect(await harness.deps.analysisQueue.getState(game.id)).toBe("none");
+    }
+  });
+});

--- a/apps/server/tests/profile-identity.test.ts
+++ b/apps/server/tests/profile-identity.test.ts
@@ -124,17 +124,14 @@ interface GameView {
   blackIdentity: SeatIdentity;
 }
 
-/** First imported game of an archive — any one will do for seat reads. */
-async function firstGameId(
-  app: AuthedApp,
-  platform: string,
-  username: string,
-): Promise<string> {
-  const page = (await (
-    await app.request(`/games?platform=${platform}&username=${username}`)
-  ).json()) as { games: { id: string }[] };
-  expect(page.games.length).toBeGreaterThan(0);
-  return page.games[0]!.id;
+/** First game of the caller's library from one source — any will do for seat reads. */
+async function firstGameId(app: AuthedApp, source = "chess_com"): Promise<string> {
+  const page = (await (await app.request("/games")).json()) as {
+    games: { id: string; source: string }[];
+  };
+  const pick = page.games.find((game) => game.source === source);
+  expect(pick, `no ${source} game in the library`).toBeDefined();
+  return pick!.id;
 }
 
 async function openGame(app: AuthedApp, gameId: string): Promise<Response> {
@@ -151,7 +148,7 @@ describe("provider profile identity on game review", () => {
 
     // Connect-time warmed my handle; the opponent's is a cold miss here.
     const before = sync.profileRequests.length;
-    const game = await firstGameId(owner, "chess_com", "looper");
+    const game = await firstGameId(owner);
     const response = await openGame(owner, game);
     expect(response.status).toBe(200);
 
@@ -166,7 +163,7 @@ describe("provider profile identity on game review", () => {
   });
 
   it("reopening the same game spends no further provider request", async () => {
-    const game = await firstGameId(owner, "chess_com", "looper");
+    const game = await firstGameId(owner);
     const before = sync.profileRequests.length;
 
     const response = await openGame(owner, game);
@@ -190,7 +187,7 @@ describe("provider profile identity on game review", () => {
     expect(connected.status).toBe(201);
 
     const before = sync.profileRequests.length;
-    const game = await firstGameId(second, "chess_com", "lister");
+    const game = await firstGameId(second);
     const response = await openGame(second, game);
     expect(response.status).toBe(200);
     const body = (await response.json()) as GameView;
@@ -224,7 +221,7 @@ describe("provider profile identity on game review", () => {
     );
     expect(created.status).toBe(201);
 
-    const game = await firstGameId(owner, "lichess", "sea-lion");
+    const game = await firstGameId(owner, "lichess");
     const response = await openGame(owner, game);
     expect(response.status).toBe(200);
 
@@ -245,7 +242,7 @@ describe("provider profile identity on game review", () => {
       const stale = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
       await harness.db.update(providerProfiles).set({ fetchedAt: stale });
 
-      const game = await firstGameId(owner, "chess_com", "looper");
+      const game = await firstGameId(owner);
       const response = await openGame(owner, game);
       expect(response.status).toBe(200);
 
@@ -265,7 +262,7 @@ describe("provider profile identity on game review", () => {
     await harness.db.update(providerProfiles).set({ fetchedAt: stale });
 
     const before = sync.profileRequests.length;
-    const game = await firstGameId(owner, "chess_com", "looper");
+    const game = await firstGameId(owner);
     const response = await openGame(owner, game);
     expect(response.status).toBe(200);
 
@@ -285,7 +282,7 @@ describe("provider profile identity on game review", () => {
       const stale = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
       await harness.db.update(providerProfiles).set({ fetchedAt: stale });
 
-      const game = await firstGameId(owner, "chess_com", "looper");
+      const game = await firstGameId(owner);
       const response = await openGame(owner, game);
       expect(response.status).toBe(200);
 

--- a/apps/server/tests/watchers.test.ts
+++ b/apps/server/tests/watchers.test.ts
@@ -27,9 +27,9 @@ beforeAll(async () => {
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ platform: "chess_com", username: "looper" }),
   });
-  const games = (await (
-    await owner.request("/games?platform=chess_com&username=looper")
-  ).json()) as { games: { id: string }[] };
+  const games = (await (await owner.request("/games")).json()) as {
+    games: { id: string }[];
+  };
   gameId = games.games[0]!.id;
 });
 

--- a/apps/web/src/auth/tests/auth.test.tsx
+++ b/apps/web/src/auth/tests/auth.test.tsx
@@ -97,14 +97,14 @@ describe("the wall", () => {
 
   it("keeps a signed-in visitor in, with no chess account selected", async () => {
     // The inverse: identity is enough to be inside the app. The games
-    // screen offers the import form instead of bouncing anyone out.
+    // screen offers the imports instead of bouncing anyone out.
     sessionActive();
     resetDevice();
 
     const { router } = await renderApp({ path: "/games" });
 
     expect(router.state.location.pathname).toBe("/games");
-    expect(await screen.findByRole("button", { name: "Import" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Import PGN" })).toBeInTheDocument();
   });
 
   it("does not leave a rejected promise when the session lookup fails", async () => {

--- a/apps/web/src/games/games-list.tsx
+++ b/apps/web/src/games/games-list.tsx
@@ -7,19 +7,18 @@ import { useMemo } from "react";
 import { DataTable, DataTablePagination } from "@velachess/ui/components/data-table";
 import { PageHeader } from "@velachess/ui/layout/page-header";
 
-import { ImportGames } from "./import/import-games.tsx";
-import { useMyAccounts } from "./import/my-accounts.ts";
+import { PgnImportButton } from "./import-pgn/pgn-import-dialog.tsx";
 import { SyncGamesButton } from "./import/sync-games-button.tsx";
 import { gamesColumns } from "./list/columns.tsx";
 import { activeFilterCount, PAGE_SIZE, type GamesSearch } from "./list/filters.ts";
 import { GamesFilters } from "./list/games-filters.tsx";
-import { archiveQuery, type Game } from "./list/queries.ts";
+import { libraryQuery, type Game } from "./list/queries.ts";
 import { useQuery } from "../shared/libs/query/index.ts";
 
 const GAMES_COPY = {
   title: msg`Games`,
   description: msg`Every game you've imported, and how it went.`,
-  emptyArchive: msg`No games imported yet.`,
+  emptyArchive: msg`No games yet. Connect Chess.com or Lichess, or import a PGN.`,
   emptyFilters: msg`No games match these filters.`,
   loadError: msg`Couldn't load games.`,
   pagination: msg`Games pages`,
@@ -54,8 +53,8 @@ export function GamesList() {
   const search = route.useSearch();
   const navigate = route.useNavigate();
 
-  const account = useMyAccounts((state) => state.accounts[0]);
-  const query = useQuery(archiveQuery(account, search));
+  // One library, every source: no account has to exist for this read.
+  const query = useQuery(libraryQuery(search));
 
   const setSearch = (next: Partial<GamesSearch>) =>
     navigate({ search: (previous) => ({ ...previous, ...next }) });
@@ -76,19 +75,10 @@ export function GamesList() {
   const actions = (
     <div className="flex items-center gap-2">
       <GamesFilters search={search} onChange={setSearch} />
+      <PgnImportButton />
       <SyncGamesButton />
     </div>
   );
-  // Import form here, not a redirect — an empty table with no way to fill it is a dead end.
-  if (!account) {
-    return (
-      <GamesScreen actions={null}>
-        <div className="mx-auto w-full max-w-lg">
-          <ImportGames />
-        </div>
-      </GamesScreen>
-    );
-  }
 
   const emptyMessage =
     activeFilterCount(search) === 0

--- a/apps/web/src/games/import-pgn/pgn-import-dialog.tsx
+++ b/apps/web/src/games/import-pgn/pgn-import-dialog.tsx
@@ -1,0 +1,203 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { useState } from "react";
+
+import { Button } from "@velachess/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@velachess/ui/components/dialog";
+import { Field, FieldError, FieldLabel } from "@velachess/ui/components/field";
+import { toast } from "@velachess/ui/components/toast";
+import { FileText } from "@velachess/ui/icons";
+import { cn } from "@velachess/ui/lib/utils";
+
+import { useImportPgn } from "./queries.ts";
+
+const COPY = {
+  action: msg`Import PGN`,
+  title: msg`Import games from a PGN`,
+  description: msg`Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs.`,
+  playerName: msg`Your name in these games`,
+  playerNameHint: msg`As it appears in the White and Black headers`,
+  playerRequired: msg`Enter your name so your games can be told apart from your opponents'.`,
+  file: msg`PGN file`,
+  paste: msg`Or paste the moves`,
+  pastePlaceholder: msg`[Event "..."] …`,
+  pgnRequired: msg`There is nothing to import yet.`,
+  submit: msg`Import`,
+  importing: msg`Importing…`,
+} as const;
+
+const RESULT_COPY = {
+  done: msg`Games imported`,
+  duplicates: msg`{count, plural, one {One was already in your library.} other {# were already in your library.}}`,
+  rejected: msg`{count, plural, one {One game could not be read.} other {# games could not be read.}}`,
+  failedTitle: msg`Import failed`,
+  failedDescription: msg`Couldn't reach the server. Try again.`,
+} as const;
+
+/**
+ * The manual source's entry point. Chess.com and Lichess connect through
+ * Import games; this is the separate, repeatable upload — no account row
+ * behind it, nothing remembered on this device.
+ */
+export function PgnImportButton() {
+  const { i18n } = useLingui();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <Button variant="outline">
+            <FileText data-icon="inline-start" />
+            {i18n._(COPY.action)}
+          </Button>
+        }
+      />
+      <DialogContent aria-labelledby={DIALOG_TITLE_ID}>
+        <DialogHeader>
+          <DialogTitle id={DIALOG_TITLE_ID}>{i18n._(COPY.title)}</DialogTitle>
+          <DialogDescription>{i18n._(COPY.description)}</DialogDescription>
+        </DialogHeader>
+        <ImportPgnForm onDone={() => setOpen(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const DIALOG_TITLE_ID = "pgn-import-title";
+
+type Translate = (message: MessageDescriptor) => string;
+
+function ImportPgnForm({ onDone }: { onDone: () => void }) {
+  const { i18n } = useLingui();
+  const [playerName, setPlayerName] = useState("");
+  const [pgn, setPgn] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  const importPgn = useImportPgn({
+    onImported: (outcome) => {
+      announce(outcome, (message) => i18n._(message));
+      onDone();
+    },
+    onError: () => {
+      toast.add({
+        type: "error",
+        title: i18n._(RESULT_COPY.failedTitle),
+        description: i18n._(RESULT_COPY.failedDescription),
+      });
+    },
+  });
+
+  const playerNameInvalid = touched && playerName.trim().length === 0;
+  const pgnInvalid = touched && pgn.trim().length === 0;
+
+  const submit = () => {
+    setTouched(true);
+    if (playerName.trim().length === 0 || pgn.trim().length === 0) return;
+    importPgn.mutate({ pgn, playerName: playerName.trim() });
+  };
+
+  const readFile = async (file: File | undefined) => {
+    if (!file) return;
+    // A .pgn is plain text by definition; read it into the paste field so
+    // there is exactly one place the import reads from.
+    setPgn(await file.text());
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <Field data-invalid={playerNameInvalid}>
+        <FieldLabel htmlFor="pgn-player-name">{i18n._(COPY.playerName)}</FieldLabel>
+        <input
+          id="pgn-player-name"
+          className={inputClassName(playerNameInvalid)}
+          value={playerName}
+          aria-invalid={playerNameInvalid}
+          onChange={(event) => setPlayerName(event.target.value)}
+          disabled={importPgn.isPending}
+        />
+        <FieldLabel
+          htmlFor="pgn-player-name"
+          className="text-muted-foreground font-normal"
+        >
+          {i18n._(COPY.playerNameHint)}
+        </FieldLabel>
+        {playerNameInvalid && <FieldError>{i18n._(COPY.playerRequired)}</FieldError>}
+      </Field>
+
+      <Field data-invalid={pgnInvalid}>
+        <FieldLabel htmlFor="pgn-file">{i18n._(COPY.file)}</FieldLabel>
+        <input
+          id="pgn-file"
+          type="file"
+          accept=".pgn,text/plain"
+          className={inputClassName(false)}
+          onChange={(event) => void readFile(event.target.files?.[0])}
+          disabled={importPgn.isPending}
+        />
+
+        <FieldLabel htmlFor="pgn-paste">{i18n._(COPY.paste)}</FieldLabel>
+        <textarea
+          id="pgn-paste"
+          rows={6}
+          value={pgn}
+          placeholder={i18n._(COPY.pastePlaceholder)}
+          aria-invalid={pgnInvalid}
+          onChange={(event) => setPgn(event.target.value)}
+          disabled={importPgn.isPending}
+          className={cn(inputClassName(pgnInvalid), "font-mono text-xs")}
+        />
+        {pgnInvalid && <FieldError>{i18n._(COPY.pgnRequired)}</FieldError>}
+      </Field>
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={importPgn.isPending}>
+          {importPgn.isPending ? i18n._(COPY.importing) : i18n._(COPY.submit)}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/** Same token classes the shared Input wears, adapted to multi-line content — local until a second consumer earns a primitive. */
+function inputClassName(invalid: boolean): string {
+  return cn(
+    "w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none",
+    "placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
+    "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+    invalid && "border-destructive ring-3 ring-destructive/20",
+  );
+}
+
+/** The receipt names every pile: what landed, what was already there, what couldn't be read. */
+function announce(
+  outcome: { duplicates: number; rejected: number },
+  translate: Translate,
+) {
+  const notes = [
+    outcome.duplicates > 0 &&
+      translate({ ...RESULT_COPY.duplicates, values: { count: outcome.duplicates } }),
+    outcome.rejected > 0 &&
+      translate({ ...RESULT_COPY.rejected, values: { count: outcome.rejected } }),
+  ].filter(Boolean);
+
+  toast.add({
+    type: "success",
+    title: translate(RESULT_COPY.done),
+    ...(notes.length > 0 ? { description: notes.join(" ") } : {}),
+  });
+}

--- a/apps/web/src/games/import-pgn/pgn-import-dialog.tsx
+++ b/apps/web/src/games/import-pgn/pgn-import-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTrigger,
 } from "@velachess/ui/components/dialog";
 import { Field, FieldError, FieldLabel } from "@velachess/ui/components/field";
+import { Input } from "@velachess/ui/components/input";
 import { toast } from "@velachess/ui/components/toast";
 import { FileText } from "@velachess/ui/icons";
 import { cn } from "@velachess/ui/lib/utils";
@@ -122,9 +123,9 @@ function ImportPgnForm({ onDone }: { onDone: () => void }) {
     >
       <Field data-invalid={playerNameInvalid}>
         <FieldLabel htmlFor="pgn-player-name">{i18n._(COPY.playerName)}</FieldLabel>
-        <input
+        <Input
           id="pgn-player-name"
-          className={inputClassName(playerNameInvalid)}
+          aria-label={i18n._(COPY.playerName)}
           value={playerName}
           aria-invalid={playerNameInvalid}
           onChange={(event) => setPlayerName(event.target.value)}
@@ -141,11 +142,11 @@ function ImportPgnForm({ onDone }: { onDone: () => void }) {
 
       <Field data-invalid={pgnInvalid}>
         <FieldLabel htmlFor="pgn-file">{i18n._(COPY.file)}</FieldLabel>
-        <input
+        <Input
           id="pgn-file"
           type="file"
           accept=".pgn,text/plain"
-          className={inputClassName(false)}
+          aria-label={i18n._(COPY.file)}
           onChange={(event) => void readFile(event.target.files?.[0])}
           disabled={importPgn.isPending}
         />

--- a/apps/web/src/games/import-pgn/queries.ts
+++ b/apps/web/src/games/import-pgn/queries.ts
@@ -1,0 +1,37 @@
+import { api, parseResponse } from "../../shared/api/client.ts";
+import { useMutation, useQueryClient } from "../../shared/libs/query/index.ts";
+
+/** What POST /games/import reports, all three counts at once. */
+export type ImportPgnOutcome = {
+  imported: number;
+  duplicates: number;
+  rejected: number;
+  judged: number;
+  seeded: number;
+};
+
+export interface ImportPgnInput {
+  pgn: string;
+  playerName?: string;
+}
+
+/**
+ * The one call a manual upload needs: no account to create, nothing to
+ * remember on this device afterwards — the refetch tells the story.
+ */
+export function useImportPgn(handlers: {
+  onImported: (outcome: ImportPgnOutcome) => void;
+  onError: () => void;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: ImportPgnInput) =>
+      parseResponse(api.games.import.$post({ json: input })),
+    onSuccess: async (outcome) => {
+      handlers.onImported(outcome);
+      await queryClient.invalidateQueries();
+    },
+    onError: handlers.onError,
+  });
+}

--- a/apps/web/src/games/import-pgn/tests/pgn-import-dialog.test.tsx
+++ b/apps/web/src/games/import-pgn/tests/pgn-import-dialog.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { addGames, stagePgnImport } from "../../../test/archive.ts";
+import { aGame } from "../../../test/games.ts";
+import { renderApp } from "../../../test/render.tsx";
+
+/**
+ * The manual import, read the way its user would: a header action that
+ * opens a form, a receipt naming every pile, and rows that actually land
+ * in the library underneath.
+ */
+describe("pgn import", () => {
+  beforeEach(() => {
+    // One row already in the library, so every test opens from a rendered
+    // list rather than an empty table.
+    addGames(aGame());
+    stagePgnImport({ incoming: [aGame({ source: "pgn", blackName: "from-the-file" })] });
+  });
+
+  async function openDialog() {
+    const { user } = await renderApp();
+    await screen.findByText("gothamchess");
+
+    await user.click(screen.getByRole("button", { name: "Import PGN" }));
+    return user;
+  }
+
+  /** Pasted, not typed: user.type reads bracket notation as keystrokes. */
+  const paste = (text: string) => {
+    fireEvent.change(screen.getByLabelText("Or paste the moves"), {
+      target: { value: text },
+    });
+  };
+
+  it("imports a pasted file and shows the new game in the library", async () => {
+    const user = await openDialog();
+
+    await user.type(screen.getByLabelText("Your name in these games"), "yurimutti");
+    paste('[Event "Pasted"]\n\n1. e4 e5 *');
+    await user.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(await screen.findByText("Games imported")).toBeInTheDocument();
+    // The receipt is not enough on its own — the refetched list must
+    // carry what landed.
+    expect(await screen.findByText("from-the-file")).toBeInTheDocument();
+  });
+
+  it("asks for the player name before importing anything", async () => {
+    const user = await openDialog();
+
+    paste('[Event "Pasted"]\n\n1. e4 e5 *');
+    await user.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(
+      await screen.findByText(
+        "Enter your name so your games can be told apart from your opponents'.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Games imported")).not.toBeInTheDocument();
+  });
+
+  it("refuses an empty upload instead of sending it", async () => {
+    const user = await openDialog();
+
+    await user.type(screen.getByLabelText("Your name in these games"), "yurimutti");
+    await user.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(
+      await screen.findByText("There is nothing to import yet."),
+    ).toBeInTheDocument();
+  });
+
+  it("counts what was already there and what could not be read", async () => {
+    stagePgnImport({
+      incoming: [],
+      duplicates: 2,
+      rejected: 1,
+    });
+
+    const user = await openDialog();
+
+    await user.type(screen.getByLabelText("Your name in these games"), "yurimutti");
+    paste('[Event "Duplicate"]\n\n1. d4 d5 *');
+    await user.click(screen.getByRole("button", { name: "Import" }));
+
+    const description = await screen.findByText(/already in your library/);
+    expect(description.textContent).toContain("2");
+    expect(description.textContent).toContain("could not be read");
+  });
+
+  it("says the import failed when the server cannot be reached", async () => {
+    stagePgnImport({ refuses: true });
+
+    const user = await openDialog();
+
+    await user.type(screen.getByLabelText("Your name in these games"), "yurimutti");
+    paste('[Event "Doomed"]\n\n1. e4 e5 *');
+    await user.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(await screen.findByText("Import failed")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/games/import-pgn/tests/pgn-import-dialog.test.tsx
+++ b/apps/web/src/games/import-pgn/tests/pgn-import-dialog.test.tsx
@@ -10,6 +10,22 @@ import { renderApp } from "../../../test/render.tsx";
  * opens a form, a receipt naming every pile, and rows that actually land
  * in the library underneath.
  */
+
+async function openDialog() {
+  const { user } = await renderApp();
+  await screen.findByText("gothamchess");
+
+  await user.click(screen.getByRole("button", { name: "Import PGN" }));
+  return user;
+}
+
+/** Pasted, not typed: user.type reads bracket notation as keystrokes. */
+const paste = (text: string) => {
+  fireEvent.change(screen.getByLabelText("Or paste the moves"), {
+    target: { value: text },
+  });
+};
+
 describe("pgn import", () => {
   beforeEach(() => {
     // One row already in the library, so every test opens from a rendered
@@ -17,21 +33,6 @@ describe("pgn import", () => {
     addGames(aGame());
     stagePgnImport({ incoming: [aGame({ source: "pgn", blackName: "from-the-file" })] });
   });
-
-  async function openDialog() {
-    const { user } = await renderApp();
-    await screen.findByText("gothamchess");
-
-    await user.click(screen.getByRole("button", { name: "Import PGN" }));
-    return user;
-  }
-
-  /** Pasted, not typed: user.type reads bracket notation as keystrokes. */
-  const paste = (text: string) => {
-    fireEvent.change(screen.getByLabelText("Or paste the moves"), {
-      target: { value: text },
-    });
-  };
 
   it("imports a pasted file and shows the new game in the library", async () => {
     const user = await openDialog();

--- a/apps/web/src/games/list/queries.ts
+++ b/apps/web/src/games/list/queries.ts
@@ -1,6 +1,5 @@
 import { api, parseResponse, type InferResponseType } from "../../shared/api/client.ts";
 import { queryOptions } from "../../shared/libs/query/index.ts";
-import type { RememberedAccount } from "../import/my-accounts.ts";
 import { PAGE_SIZE, type GamesSearch } from "./filters.ts";
 
 type GameRow = InferResponseType<typeof api.games.$get, 200>["games"][number];
@@ -22,20 +21,19 @@ export type Game = Pick<
   | "openingName"
 >;
 
-/** Account + search both live in the cache key so switching either avoids a flash of stale rows; account may be absent (disabled query). */
-export function archiveQuery(
-  account: RememberedAccount | undefined,
-  search: GamesSearch,
-) {
+/**
+ * The user's unified library: synced accounts and manual PGN imports in
+ * one list, so neither the account nor its absence gates the read.
+ * Search lives in the cache key so changing a filter avoids a flash of
+ * stale rows.
+ */
+export function libraryQuery(search: GamesSearch) {
   return queryOptions({
-    queryKey: ["games", account?.accountId ?? "none", search],
-    enabled: account !== undefined,
+    queryKey: ["games", search],
     queryFn: () =>
       parseResponse(
         api.games.$get({
           query: {
-            platform: account!.platform,
-            username: account!.username,
             ...(search.color ? { color: search.color } : {}),
             ...(search.outcome ? { outcome: search.outcome } : {}),
             ...(search.timeClass ? { timeClass: search.timeClass } : {}),

--- a/apps/web/src/games/tests/games-list.test.tsx
+++ b/apps/web/src/games/tests/games-list.test.tsx
@@ -119,10 +119,14 @@ describe("games list", () => {
     expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
   });
 
-  it("says there are no imported games when the archive is empty", async () => {
+  it("says there are no imported games when the library is empty", async () => {
     await renderApp();
 
-    expect(await screen.findByText("No games imported yet.")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "No games yet. Connect Chess.com or Lichess, or import a PGN.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("says the filters matched nothing rather than showing a blank table", async () => {
@@ -184,14 +188,15 @@ describe("games list", () => {
     expect(link).toHaveAttribute("href", "/games/game-1");
   });
 
-  it("offers the import form when no account is connected", async () => {
-    // No redirect: being signed in is enough to be here, and a table with
-    // no rows and no way to fill it is a dead end. The form is the empty
-    // state.
+  it("lists the library and offers both import paths with no account connected", async () => {
+    // The unified read does not depend on a remembered handle: a manual
+    // import alone is a first-class way to have a library, and both ways
+    // to fill it stay reachable from the header.
     resetDevice();
     const { router } = await renderApp();
 
     expect(router.state.location.pathname).toBe("/games");
-    expect(screen.getByRole("button", { name: "Import" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import PGN" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sync games" })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -21,6 +21,10 @@ msgstr "Preparing analysis…"
 msgid "—"
 msgstr "—"
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:30
+msgid "[Event \"...\"] …"
+msgstr "[Event \"...\"] …"
+
 #: src/repertoire/repertoire-detail.tsx:30
 msgid "{color} · {chapters, plural, one {# chapter} other {# chapters}}"
 msgstr "{color} · {chapters, plural, one {# chapter} other {# chapters}}"
@@ -50,6 +54,14 @@ msgstr "{count, plural, one {# recall failure} other {# recall failures}}"
 #: src/repertoire/repertoire-detail.tsx:44
 msgid "{count, plural, one {in # game} other {in # games}}"
 msgstr "{count, plural, one {in # game} other {in # games}}"
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:39
+msgid "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
+msgstr "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:38
+msgid "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
+msgstr "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
 
 #: src/repertoire/repertoire-detail.tsx:33
 msgid "{count} due"
@@ -162,6 +174,10 @@ msgstr "Appearance"
 msgid "Application theme"
 msgstr "Application theme"
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:26
+msgid "As it appears in the White and Black headers"
+msgstr "As it appears in the White and Black headers"
+
 #: src/onboarding/onboarding-dialog.tsx:24
 msgid "Back"
 msgstr "Back"
@@ -205,7 +221,7 @@ msgstr "Black repertoire"
 msgid "Black to move"
 msgstr "Black to move"
 
-#: src/games/games-list.tsx:29
+#: src/games/games-list.tsx:28
 #: src/games/list/columns.tsx:23
 #: src/games/list/filters.ts:49
 msgid "Blitz"
@@ -228,11 +244,11 @@ msgstr "Blunders per game"
 msgid "Board"
 msgstr "Board"
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr "Board interaction preferences."
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr "Board preferences like coordinates, move animation, and sound will land here once they exist."
 
@@ -240,7 +256,7 @@ msgstr "Board preferences like coordinates, move animation, and sound will land 
 msgid "Built from your games"
 msgstr "Built from your games"
 
-#: src/games/games-list.tsx:28
+#: src/games/games-list.tsx:27
 #: src/games/list/columns.tsx:22
 #: src/games/list/filters.ts:48
 msgid "Bullet"
@@ -254,7 +270,7 @@ msgstr "Chapter"
 msgid "Chess.com username"
 msgstr "Chess.com username"
 
-#: src/games/games-list.tsx:31
+#: src/games/games-list.tsx:30
 #: src/games/list/columns.tsx:25
 #: src/games/list/filters.ts:51
 msgid "Classical"
@@ -322,7 +338,7 @@ msgstr "Couldn't load analysis."
 msgid "Couldn't load drills."
 msgstr "Couldn't load drills."
 
-#: src/games/games-list.tsx:24
+#: src/games/games-list.tsx:23
 msgid "Couldn't load games."
 msgstr "Couldn't load games."
 
@@ -362,6 +378,10 @@ msgstr "Couldn't reach that account"
 #: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr "Couldn't reach the server. Try again in a moment."
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:41
+msgid "Couldn't reach the server. Try again."
+msgstr "Couldn't reach the server. Try again."
 
 #: src/settings/account/profile-form.tsx:31
 msgid "Couldn't save that. Try again."
@@ -440,6 +460,10 @@ msgstr "Enter a name."
 msgid "Enter your email."
 msgstr "Enter your email."
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:27
+msgid "Enter your name so your games can be told apart from your opponents'."
+msgstr "Enter your name so your games can be told apart from your opponents'."
+
 #: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "Enter your password."
 msgstr "Enter your password."
@@ -457,7 +481,7 @@ msgstr "Evaluation"
 msgid "Evaluation over the game"
 msgstr "Evaluation over the game"
 
-#: src/games/games-list.tsx:21
+#: src/games/games-list.tsx:20
 msgid "Every game you've imported, and how it went."
 msgstr "Every game you've imported, and how it went."
 
@@ -507,20 +531,24 @@ msgid "Game phases"
 msgstr "Game phases"
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
 msgstr "Gameplay"
 
 #: src/dashboard/dashboard.tsx:23
-#: src/games/games-list.tsx:20
+#: src/games/games-list.tsx:19
 #: src/routes/_app/games.tsx:6
 #: src/test/routes.tsx:81
 msgid "Games"
 msgstr "Games"
 
-#: src/games/games-list.tsx:25
+#: src/games/import-pgn/pgn-import-dialog.tsx:37
+msgid "Games imported"
+msgstr "Games imported"
+
+#: src/games/games-list.tsx:24
 msgid "Games pages"
 msgstr "Games pages"
 
@@ -552,13 +580,26 @@ msgstr "How VelaChess looks on this device."
 msgid "How you're shown in the app."
 msgstr "How you're shown in the app."
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:32
 #: src/games/import/sources.ts:79
 msgid "Import"
 msgstr "Import"
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:40
+msgid "Import failed"
+msgstr "Import failed"
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:23
+msgid "Import games from a PGN"
+msgstr "Import games from a PGN"
+
 #: src/drill/drill.tsx:49
 msgid "Import or analyze a game and new positions land here on their own."
 msgstr "Import or analyze a game and new positions land here on their own."
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:22
+msgid "Import PGN"
+msgstr "Import PGN"
 
 #: src/games/import/sources.ts:77
 msgid "Import your games"
@@ -567,6 +608,10 @@ msgstr "Import your games"
 #: src/dashboard/dashboard.tsx:23
 msgid "imported from your accounts"
 msgstr "imported from your accounts"
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:33
+msgid "Importing…"
+msgstr "Importing…"
 
 #: src/drill/drill-prompt.tsx:20
 msgid "In the game, you played"
@@ -749,7 +794,7 @@ msgstr "new"
 msgid "New games imported"
 msgstr "New games imported"
 
-#: src/games/games-list.tsx:27
+#: src/games/games-list.tsx:26
 #: src/games/open-game/replay-controls.tsx:13
 #: src/onboarding/onboarding-dialog.tsx:23
 #: src/repertoire/chapter-study.tsx:61
@@ -777,17 +822,17 @@ msgstr "No chapters yet"
 msgid "No games found for that username. Check the spelling and try again."
 msgstr "No games found for that username. Check the spelling and try again."
 
-#: src/games/games-list.tsx:22
-msgid "No games imported yet."
-msgstr "No games imported yet."
-
 #: src/repertoire/repertoire-landing.tsx:34
 msgid "No games judged against it yet"
 msgstr "No games judged against it yet"
 
-#: src/games/games-list.tsx:23
+#: src/games/games-list.tsx:22
 msgid "No games match these filters."
 msgstr "No games match these filters."
+
+#: src/games/games-list.tsx:21
+msgid "No games yet. Connect Chess.com or Lichess, or import a PGN."
+msgstr "No games yet. Connect Chess.com or Lichess, or import a PGN."
 
 #: src/games/import/sync-games-button.tsx:21
 #: src/settings/connections/connections-screen.tsx:42
@@ -818,7 +863,7 @@ msgstr "Nothing due today"
 msgid "Nothing in the position was worth more."
 msgstr "Nothing in the position was worth more."
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr "Nothing to configure yet"
 
@@ -866,13 +911,25 @@ msgstr "Opponent plays:"
 msgid "Or continue with"
 msgstr "Or continue with"
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:29
+msgid "Or paste the moves"
+msgstr "Or paste the moves"
+
 #: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Password"
 msgstr "Password"
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:24
+msgid "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
+msgstr "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
+
 #: src/insights/insights.tsx:48
 msgid "Performance"
 msgstr "Performance"
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:28
+msgid "PGN file"
+msgstr "PGN file"
 
 #: src/drill/drill-prompt.tsx:21
 #: src/repertoire/repertoire-practice.tsx:57
@@ -930,7 +987,7 @@ msgstr "Prepared move:"
 msgid "Prev"
 msgstr "Prev"
 
-#: src/games/games-list.tsx:26
+#: src/games/games-list.tsx:25
 msgid "Previous"
 msgstr "Previous"
 
@@ -948,7 +1005,7 @@ msgstr "Profile"
 msgid "Progress"
 msgstr "Progress"
 
-#: src/games/games-list.tsx:30
+#: src/games/games-list.tsx:29
 #: src/games/list/columns.tsx:24
 #: src/games/list/filters.ts:50
 msgid "Rapid"
@@ -1175,6 +1232,10 @@ msgstr "The prepared line ends here."
 #: src/games/view-analysis/move-insight.tsx:20
 msgid "The starting position."
 msgstr "The starting position."
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:31
+msgid "There is nothing to import yet."
+msgstr "There is nothing to import yet."
 
 #: src/repertoire/repertoire-detail.tsx:41
 msgid "This repertoire is derived from your games. Sync a few more and its chapters appear here on their own."
@@ -1408,6 +1469,10 @@ msgstr "Your last {n} games are a clear step up"
 #: src/insights/finding-views.tsx:499
 msgid "Your last {n} games have slipped"
 msgstr "Your last {n} games have slipped"
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:25
+msgid "Your name in these games"
+msgstr "Your name in these games"
 
 #: src/insights/finding-views.tsx:90
 msgid "Your preparation is paying off with Black"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -21,7 +21,7 @@ msgstr "Preparing analysis…"
 msgid "—"
 msgstr "—"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:30
+#: src/games/import-pgn/pgn-import-dialog.tsx:32
 msgid "[Event \"...\"] …"
 msgstr "[Event \"...\"] …"
 
@@ -55,11 +55,11 @@ msgstr "{count, plural, one {# recall failure} other {# recall failures}}"
 msgid "{count, plural, one {in # game} other {in # games}}"
 msgstr "{count, plural, one {in # game} other {in # games}}"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:39
+#: src/games/import-pgn/pgn-import-dialog.tsx:41
 msgid "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
 msgstr "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:38
+#: src/games/import-pgn/pgn-import-dialog.tsx:40
 msgid "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
 msgstr "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
 
@@ -174,7 +174,7 @@ msgstr "Appearance"
 msgid "Application theme"
 msgstr "Application theme"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:26
+#: src/games/import-pgn/pgn-import-dialog.tsx:28
 msgid "As it appears in the White and Black headers"
 msgstr "As it appears in the White and Black headers"
 
@@ -379,7 +379,7 @@ msgstr "Couldn't reach that account"
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr "Couldn't reach the server. Try again in a moment."
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:41
+#: src/games/import-pgn/pgn-import-dialog.tsx:43
 msgid "Couldn't reach the server. Try again."
 msgstr "Couldn't reach the server. Try again."
 
@@ -460,7 +460,7 @@ msgstr "Enter a name."
 msgid "Enter your email."
 msgstr "Enter your email."
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:27
+#: src/games/import-pgn/pgn-import-dialog.tsx:29
 msgid "Enter your name so your games can be told apart from your opponents'."
 msgstr "Enter your name so your games can be told apart from your opponents'."
 
@@ -544,7 +544,7 @@ msgstr "Gameplay"
 msgid "Games"
 msgstr "Games"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:37
+#: src/games/import-pgn/pgn-import-dialog.tsx:39
 msgid "Games imported"
 msgstr "Games imported"
 
@@ -580,16 +580,16 @@ msgstr "How VelaChess looks on this device."
 msgid "How you're shown in the app."
 msgstr "How you're shown in the app."
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:32
+#: src/games/import-pgn/pgn-import-dialog.tsx:34
 #: src/games/import/sources.ts:79
 msgid "Import"
 msgstr "Import"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:40
+#: src/games/import-pgn/pgn-import-dialog.tsx:42
 msgid "Import failed"
 msgstr "Import failed"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:23
+#: src/games/import-pgn/pgn-import-dialog.tsx:25
 msgid "Import games from a PGN"
 msgstr "Import games from a PGN"
 
@@ -597,7 +597,7 @@ msgstr "Import games from a PGN"
 msgid "Import or analyze a game and new positions land here on their own."
 msgstr "Import or analyze a game and new positions land here on their own."
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:22
+#: src/games/import-pgn/pgn-import-dialog.tsx:24
 msgid "Import PGN"
 msgstr "Import PGN"
 
@@ -609,7 +609,7 @@ msgstr "Import your games"
 msgid "imported from your accounts"
 msgstr "imported from your accounts"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:33
+#: src/games/import-pgn/pgn-import-dialog.tsx:35
 msgid "Importing…"
 msgstr "Importing…"
 
@@ -911,7 +911,7 @@ msgstr "Opponent plays:"
 msgid "Or continue with"
 msgstr "Or continue with"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:29
+#: src/games/import-pgn/pgn-import-dialog.tsx:31
 msgid "Or paste the moves"
 msgstr "Or paste the moves"
 
@@ -919,7 +919,7 @@ msgstr "Or paste the moves"
 msgid "Password"
 msgstr "Password"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:24
+#: src/games/import-pgn/pgn-import-dialog.tsx:26
 msgid "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
 msgstr "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
 
@@ -927,7 +927,7 @@ msgstr "Paste a PGN or pick a file. Your games join the same library — nothing
 msgid "Performance"
 msgstr "Performance"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:28
+#: src/games/import-pgn/pgn-import-dialog.tsx:30
 msgid "PGN file"
 msgstr "PGN file"
 
@@ -1233,7 +1233,7 @@ msgstr "The prepared line ends here."
 msgid "The starting position."
 msgstr "The starting position."
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:31
+#: src/games/import-pgn/pgn-import-dialog.tsx:33
 msgid "There is nothing to import yet."
 msgstr "There is nothing to import yet."
 
@@ -1470,7 +1470,7 @@ msgstr "Your last {n} games are a clear step up"
 msgid "Your last {n} games have slipped"
 msgstr "Your last {n} games have slipped"
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:25
+#: src/games/import-pgn/pgn-import-dialog.tsx:27
 msgid "Your name in these games"
 msgstr "Your name in these games"
 

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "—"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:30
+msgid "[Event \"...\"] …"
+msgstr ""
+
 #: src/repertoire/repertoire-detail.tsx:30
 msgid "{color} · {chapters, plural, one {# chapter} other {# chapters}}"
 msgstr ""
@@ -49,6 +53,14 @@ msgstr ""
 
 #: src/repertoire/repertoire-detail.tsx:44
 msgid "{count, plural, one {in # game} other {in # games}}"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:39
+msgid "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:38
+msgid "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
 msgstr ""
 
 #: src/repertoire/repertoire-detail.tsx:33
@@ -162,6 +174,10 @@ msgstr ""
 msgid "Application theme"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:26
+msgid "As it appears in the White and Black headers"
+msgstr ""
+
 #: src/onboarding/onboarding-dialog.tsx:24
 msgid "Back"
 msgstr ""
@@ -205,7 +221,7 @@ msgstr ""
 msgid "Black to move"
 msgstr ""
 
-#: src/games/games-list.tsx:29
+#: src/games/games-list.tsx:28
 #: src/games/list/columns.tsx:23
 #: src/games/list/filters.ts:49
 msgid "Blitz"
@@ -228,11 +244,11 @@ msgstr ""
 msgid "Board"
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr ""
 
@@ -240,7 +256,7 @@ msgstr ""
 msgid "Built from your games"
 msgstr ""
 
-#: src/games/games-list.tsx:28
+#: src/games/games-list.tsx:27
 #: src/games/list/columns.tsx:22
 #: src/games/list/filters.ts:48
 msgid "Bullet"
@@ -254,7 +270,7 @@ msgstr ""
 msgid "Chess.com username"
 msgstr ""
 
-#: src/games/games-list.tsx:31
+#: src/games/games-list.tsx:30
 #: src/games/list/columns.tsx:25
 #: src/games/list/filters.ts:51
 msgid "Classical"
@@ -322,7 +338,7 @@ msgstr ""
 msgid "Couldn't load drills."
 msgstr ""
 
-#: src/games/games-list.tsx:24
+#: src/games/games-list.tsx:23
 msgid "Couldn't load games."
 msgstr ""
 
@@ -361,6 +377,10 @@ msgstr ""
 
 #: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Couldn't reach the server. Try again in a moment."
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:41
+msgid "Couldn't reach the server. Try again."
 msgstr ""
 
 #: src/settings/account/profile-form.tsx:31
@@ -440,6 +460,10 @@ msgstr ""
 msgid "Enter your email."
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:27
+msgid "Enter your name so your games can be told apart from your opponents'."
+msgstr ""
+
 #: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "Enter your password."
 msgstr ""
@@ -457,7 +481,7 @@ msgstr ""
 msgid "Evaluation over the game"
 msgstr ""
 
-#: src/games/games-list.tsx:21
+#: src/games/games-list.tsx:20
 msgid "Every game you've imported, and how it went."
 msgstr ""
 
@@ -507,20 +531,24 @@ msgid "Game phases"
 msgstr ""
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
 msgstr ""
 
 #: src/dashboard/dashboard.tsx:23
-#: src/games/games-list.tsx:20
+#: src/games/games-list.tsx:19
 #: src/routes/_app/games.tsx:6
 #: src/test/routes.tsx:81
 msgid "Games"
 msgstr ""
 
-#: src/games/games-list.tsx:25
+#: src/games/import-pgn/pgn-import-dialog.tsx:37
+msgid "Games imported"
+msgstr ""
+
+#: src/games/games-list.tsx:24
 msgid "Games pages"
 msgstr ""
 
@@ -552,12 +580,25 @@ msgstr ""
 msgid "How you're shown in the app."
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:32
 #: src/games/import/sources.ts:79
 msgid "Import"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:40
+msgid "Import failed"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:23
+msgid "Import games from a PGN"
+msgstr ""
+
 #: src/drill/drill.tsx:49
 msgid "Import or analyze a game and new positions land here on their own."
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:22
+msgid "Import PGN"
 msgstr ""
 
 #: src/games/import/sources.ts:77
@@ -566,6 +607,10 @@ msgstr ""
 
 #: src/dashboard/dashboard.tsx:23
 msgid "imported from your accounts"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:33
+msgid "Importing…"
 msgstr ""
 
 #: src/drill/drill-prompt.tsx:20
@@ -749,7 +794,7 @@ msgstr ""
 msgid "New games imported"
 msgstr ""
 
-#: src/games/games-list.tsx:27
+#: src/games/games-list.tsx:26
 #: src/games/open-game/replay-controls.tsx:13
 #: src/onboarding/onboarding-dialog.tsx:23
 #: src/repertoire/chapter-study.tsx:61
@@ -777,16 +822,16 @@ msgstr ""
 msgid "No games found for that username. Check the spelling and try again."
 msgstr ""
 
-#: src/games/games-list.tsx:22
-msgid "No games imported yet."
-msgstr ""
-
 #: src/repertoire/repertoire-landing.tsx:34
 msgid "No games judged against it yet"
 msgstr ""
 
-#: src/games/games-list.tsx:23
+#: src/games/games-list.tsx:22
 msgid "No games match these filters."
+msgstr ""
+
+#: src/games/games-list.tsx:21
+msgid "No games yet. Connect Chess.com or Lichess, or import a PGN."
 msgstr ""
 
 #: src/games/import/sync-games-button.tsx:21
@@ -818,7 +863,7 @@ msgstr ""
 msgid "Nothing in the position was worth more."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr ""
 
@@ -866,12 +911,24 @@ msgstr ""
 msgid "Or continue with"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:29
+msgid "Or paste the moves"
+msgstr ""
+
 #: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Password"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:24
+msgid "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
+msgstr ""
+
 #: src/insights/insights.tsx:48
 msgid "Performance"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:28
+msgid "PGN file"
 msgstr ""
 
 #: src/drill/drill-prompt.tsx:21
@@ -930,7 +987,7 @@ msgstr ""
 msgid "Prev"
 msgstr ""
 
-#: src/games/games-list.tsx:26
+#: src/games/games-list.tsx:25
 msgid "Previous"
 msgstr ""
 
@@ -948,7 +1005,7 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: src/games/games-list.tsx:30
+#: src/games/games-list.tsx:29
 #: src/games/list/columns.tsx:24
 #: src/games/list/filters.ts:50
 msgid "Rapid"
@@ -1174,6 +1231,10 @@ msgstr ""
 
 #: src/games/view-analysis/move-insight.tsx:20
 msgid "The starting position."
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:31
+msgid "There is nothing to import yet."
 msgstr ""
 
 #: src/repertoire/repertoire-detail.tsx:41
@@ -1407,6 +1468,10 @@ msgstr ""
 
 #: src/insights/finding-views.tsx:499
 msgid "Your last {n} games have slipped"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:25
+msgid "Your name in these games"
 msgstr ""
 
 #: src/insights/finding-views.tsx:90

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:30
+#: src/games/import-pgn/pgn-import-dialog.tsx:32
 msgid "[Event \"...\"] …"
 msgstr ""
 
@@ -55,11 +55,11 @@ msgstr ""
 msgid "{count, plural, one {in # game} other {in # games}}"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:39
+#: src/games/import-pgn/pgn-import-dialog.tsx:41
 msgid "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:38
+#: src/games/import-pgn/pgn-import-dialog.tsx:40
 msgid "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
 msgstr ""
 
@@ -174,7 +174,7 @@ msgstr ""
 msgid "Application theme"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:26
+#: src/games/import-pgn/pgn-import-dialog.tsx:28
 msgid "As it appears in the White and Black headers"
 msgstr ""
 
@@ -379,7 +379,7 @@ msgstr ""
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:41
+#: src/games/import-pgn/pgn-import-dialog.tsx:43
 msgid "Couldn't reach the server. Try again."
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Enter your email."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:27
+#: src/games/import-pgn/pgn-import-dialog.tsx:29
 msgid "Enter your name so your games can be told apart from your opponents'."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Games"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:37
+#: src/games/import-pgn/pgn-import-dialog.tsx:39
 msgid "Games imported"
 msgstr ""
 
@@ -580,16 +580,16 @@ msgstr ""
 msgid "How you're shown in the app."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:32
+#: src/games/import-pgn/pgn-import-dialog.tsx:34
 #: src/games/import/sources.ts:79
 msgid "Import"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:40
+#: src/games/import-pgn/pgn-import-dialog.tsx:42
 msgid "Import failed"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:23
+#: src/games/import-pgn/pgn-import-dialog.tsx:25
 msgid "Import games from a PGN"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "Import or analyze a game and new positions land here on their own."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:22
+#: src/games/import-pgn/pgn-import-dialog.tsx:24
 msgid "Import PGN"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "imported from your accounts"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:33
+#: src/games/import-pgn/pgn-import-dialog.tsx:35
 msgid "Importing…"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Or continue with"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:29
+#: src/games/import-pgn/pgn-import-dialog.tsx:31
 msgid "Or paste the moves"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:24
+#: src/games/import-pgn/pgn-import-dialog.tsx:26
 msgid "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:28
+#: src/games/import-pgn/pgn-import-dialog.tsx:30
 msgid "PGN file"
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "The starting position."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:31
+#: src/games/import-pgn/pgn-import-dialog.tsx:33
 msgid "There is nothing to import yet."
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Your last {n} games have slipped"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:25
+#: src/games/import-pgn/pgn-import-dialog.tsx:27
 msgid "Your name in these games"
 msgstr ""
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "—"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:30
+msgid "[Event \"...\"] …"
+msgstr ""
+
 #: src/repertoire/repertoire-detail.tsx:30
 msgid "{color} · {chapters, plural, one {# chapter} other {# chapters}}"
 msgstr ""
@@ -49,6 +53,14 @@ msgstr ""
 
 #: src/repertoire/repertoire-detail.tsx:44
 msgid "{count, plural, one {in # game} other {in # games}}"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:39
+msgid "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:38
+msgid "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
 msgstr ""
 
 #: src/repertoire/repertoire-detail.tsx:33
@@ -162,6 +174,10 @@ msgstr ""
 msgid "Application theme"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:26
+msgid "As it appears in the White and Black headers"
+msgstr ""
+
 #: src/onboarding/onboarding-dialog.tsx:24
 msgid "Back"
 msgstr ""
@@ -205,7 +221,7 @@ msgstr ""
 msgid "Black to move"
 msgstr ""
 
-#: src/games/games-list.tsx:29
+#: src/games/games-list.tsx:28
 #: src/games/list/columns.tsx:23
 #: src/games/list/filters.ts:49
 msgid "Blitz"
@@ -228,11 +244,11 @@ msgstr ""
 msgid "Board"
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr ""
 
@@ -240,7 +256,7 @@ msgstr ""
 msgid "Built from your games"
 msgstr ""
 
-#: src/games/games-list.tsx:28
+#: src/games/games-list.tsx:27
 #: src/games/list/columns.tsx:22
 #: src/games/list/filters.ts:48
 msgid "Bullet"
@@ -254,7 +270,7 @@ msgstr ""
 msgid "Chess.com username"
 msgstr ""
 
-#: src/games/games-list.tsx:31
+#: src/games/games-list.tsx:30
 #: src/games/list/columns.tsx:25
 #: src/games/list/filters.ts:51
 msgid "Classical"
@@ -322,7 +338,7 @@ msgstr ""
 msgid "Couldn't load drills."
 msgstr ""
 
-#: src/games/games-list.tsx:24
+#: src/games/games-list.tsx:23
 msgid "Couldn't load games."
 msgstr ""
 
@@ -361,6 +377,10 @@ msgstr ""
 
 #: src/auth/sign-in/sign-in-screen.tsx:44
 msgid "Couldn't reach the server. Try again in a moment."
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:41
+msgid "Couldn't reach the server. Try again."
 msgstr ""
 
 #: src/settings/account/profile-form.tsx:31
@@ -440,6 +460,10 @@ msgstr ""
 msgid "Enter your email."
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:27
+msgid "Enter your name so your games can be told apart from your opponents'."
+msgstr ""
+
 #: src/auth/sign-in/sign-in-screen.tsx:47
 msgid "Enter your password."
 msgstr ""
@@ -457,7 +481,7 @@ msgstr ""
 msgid "Evaluation over the game"
 msgstr ""
 
-#: src/games/games-list.tsx:21
+#: src/games/games-list.tsx:20
 msgid "Every game you've imported, and how it went."
 msgstr ""
 
@@ -507,20 +531,24 @@ msgid "Game phases"
 msgstr ""
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
 msgstr ""
 
 #: src/dashboard/dashboard.tsx:23
-#: src/games/games-list.tsx:20
+#: src/games/games-list.tsx:19
 #: src/routes/_app/games.tsx:6
 #: src/test/routes.tsx:81
 msgid "Games"
 msgstr ""
 
-#: src/games/games-list.tsx:25
+#: src/games/import-pgn/pgn-import-dialog.tsx:37
+msgid "Games imported"
+msgstr ""
+
+#: src/games/games-list.tsx:24
 msgid "Games pages"
 msgstr ""
 
@@ -552,12 +580,25 @@ msgstr ""
 msgid "How you're shown in the app."
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:32
 #: src/games/import/sources.ts:79
 msgid "Import"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:40
+msgid "Import failed"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:23
+msgid "Import games from a PGN"
+msgstr ""
+
 #: src/drill/drill.tsx:49
 msgid "Import or analyze a game and new positions land here on their own."
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:22
+msgid "Import PGN"
 msgstr ""
 
 #: src/games/import/sources.ts:77
@@ -566,6 +607,10 @@ msgstr ""
 
 #: src/dashboard/dashboard.tsx:23
 msgid "imported from your accounts"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:33
+msgid "Importing…"
 msgstr ""
 
 #: src/drill/drill-prompt.tsx:20
@@ -749,7 +794,7 @@ msgstr ""
 msgid "New games imported"
 msgstr ""
 
-#: src/games/games-list.tsx:27
+#: src/games/games-list.tsx:26
 #: src/games/open-game/replay-controls.tsx:13
 #: src/onboarding/onboarding-dialog.tsx:23
 #: src/repertoire/chapter-study.tsx:61
@@ -777,16 +822,16 @@ msgstr ""
 msgid "No games found for that username. Check the spelling and try again."
 msgstr ""
 
-#: src/games/games-list.tsx:22
-msgid "No games imported yet."
-msgstr ""
-
 #: src/repertoire/repertoire-landing.tsx:34
 msgid "No games judged against it yet"
 msgstr ""
 
-#: src/games/games-list.tsx:23
+#: src/games/games-list.tsx:22
 msgid "No games match these filters."
+msgstr ""
+
+#: src/games/games-list.tsx:21
+msgid "No games yet. Connect Chess.com or Lichess, or import a PGN."
 msgstr ""
 
 #: src/games/import/sync-games-button.tsx:21
@@ -818,7 +863,7 @@ msgstr ""
 msgid "Nothing in the position was worth more."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr ""
 
@@ -866,12 +911,24 @@ msgstr ""
 msgid "Or continue with"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:29
+msgid "Or paste the moves"
+msgstr ""
+
 #: src/auth/sign-in/sign-in-screen.tsx:40
 msgid "Password"
 msgstr ""
 
+#: src/games/import-pgn/pgn-import-dialog.tsx:24
+msgid "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
+msgstr ""
+
 #: src/insights/insights.tsx:48
 msgid "Performance"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:28
+msgid "PGN file"
 msgstr ""
 
 #: src/drill/drill-prompt.tsx:21
@@ -930,7 +987,7 @@ msgstr ""
 msgid "Prev"
 msgstr ""
 
-#: src/games/games-list.tsx:26
+#: src/games/games-list.tsx:25
 msgid "Previous"
 msgstr ""
 
@@ -948,7 +1005,7 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: src/games/games-list.tsx:30
+#: src/games/games-list.tsx:29
 #: src/games/list/columns.tsx:24
 #: src/games/list/filters.ts:50
 msgid "Rapid"
@@ -1174,6 +1231,10 @@ msgstr ""
 
 #: src/games/view-analysis/move-insight.tsx:20
 msgid "The starting position."
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:31
+msgid "There is nothing to import yet."
 msgstr ""
 
 #: src/repertoire/repertoire-detail.tsx:41
@@ -1407,6 +1468,10 @@ msgstr ""
 
 #: src/insights/finding-views.tsx:499
 msgid "Your last {n} games have slipped"
+msgstr ""
+
+#: src/games/import-pgn/pgn-import-dialog.tsx:25
+msgid "Your name in these games"
 msgstr ""
 
 #: src/insights/finding-views.tsx:90

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:30
+#: src/games/import-pgn/pgn-import-dialog.tsx:32
 msgid "[Event \"...\"] …"
 msgstr ""
 
@@ -55,11 +55,11 @@ msgstr ""
 msgid "{count, plural, one {in # game} other {in # games}}"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:39
+#: src/games/import-pgn/pgn-import-dialog.tsx:41
 msgid "{count, plural, one {One game could not be read.} other {# games could not be read.}}"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:38
+#: src/games/import-pgn/pgn-import-dialog.tsx:40
 msgid "{count, plural, one {One was already in your library.} other {# were already in your library.}}"
 msgstr ""
 
@@ -174,7 +174,7 @@ msgstr ""
 msgid "Application theme"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:26
+#: src/games/import-pgn/pgn-import-dialog.tsx:28
 msgid "As it appears in the White and Black headers"
 msgstr ""
 
@@ -379,7 +379,7 @@ msgstr ""
 msgid "Couldn't reach the server. Try again in a moment."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:41
+#: src/games/import-pgn/pgn-import-dialog.tsx:43
 msgid "Couldn't reach the server. Try again."
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Enter your email."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:27
+#: src/games/import-pgn/pgn-import-dialog.tsx:29
 msgid "Enter your name so your games can be told apart from your opponents'."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Games"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:37
+#: src/games/import-pgn/pgn-import-dialog.tsx:39
 msgid "Games imported"
 msgstr ""
 
@@ -580,16 +580,16 @@ msgstr ""
 msgid "How you're shown in the app."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:32
+#: src/games/import-pgn/pgn-import-dialog.tsx:34
 #: src/games/import/sources.ts:79
 msgid "Import"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:40
+#: src/games/import-pgn/pgn-import-dialog.tsx:42
 msgid "Import failed"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:23
+#: src/games/import-pgn/pgn-import-dialog.tsx:25
 msgid "Import games from a PGN"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "Import or analyze a game and new positions land here on their own."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:22
+#: src/games/import-pgn/pgn-import-dialog.tsx:24
 msgid "Import PGN"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "imported from your accounts"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:33
+#: src/games/import-pgn/pgn-import-dialog.tsx:35
 msgid "Importing…"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Or continue with"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:29
+#: src/games/import-pgn/pgn-import-dialog.tsx:31
 msgid "Or paste the moves"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:24
+#: src/games/import-pgn/pgn-import-dialog.tsx:26
 msgid "Paste a PGN or pick a file. Your games join the same library — nothing is connected and nothing syncs."
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:28
+#: src/games/import-pgn/pgn-import-dialog.tsx:30
 msgid "PGN file"
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "The starting position."
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:31
+#: src/games/import-pgn/pgn-import-dialog.tsx:33
 msgid "There is nothing to import yet."
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Your last {n} games have slipped"
 msgstr ""
 
-#: src/games/import-pgn/pgn-import-dialog.tsx:25
+#: src/games/import-pgn/pgn-import-dialog.tsx:27
 msgid "Your name in these games"
 msgstr ""
 

--- a/apps/web/src/test/archive.ts
+++ b/apps/web/src/test/archive.ts
@@ -71,6 +71,7 @@ let state: ArchiveState = fresh();
 
 export function resetArchive(): void {
   state = fresh();
+  pgnImportState = freshImportPlan();
   resetGameIds();
 }
 
@@ -136,6 +137,42 @@ export function countWatch(): number {
 
 export function analysisAnswerFor(gameId: string): AnalysisAnswer | undefined {
   return state.analyses.get(gameId);
+}
+
+/**
+ * What the next PGN upload does. Success lands its games in the library;
+ * `refuses` answers like an unreachable server. Reset with the archive.
+ */
+export interface PgnImportPlan {
+  incoming: Game[];
+  duplicates: number;
+  rejected: number;
+  refuses: boolean;
+}
+
+function freshImportPlan(): PgnImportPlan {
+  return { incoming: [], duplicates: 0, rejected: 0, refuses: false };
+}
+
+let pgnImportState: PgnImportPlan = freshImportPlan();
+
+export const pgnImport = {
+  get incoming() {
+    return pgnImportState.incoming;
+  },
+  get duplicates() {
+    return pgnImportState.duplicates;
+  },
+  get rejected() {
+    return pgnImportState.rejected;
+  },
+  get refuses() {
+    return pgnImportState.refuses;
+  },
+};
+
+export function stagePgnImport(plan: Partial<PgnImportPlan>): void {
+  pgnImportState = { ...freshImportPlan(), ...plan };
 }
 
 /** Unknown player -> 404, not an empty archive — how a test tells "no such user" from "no games yet". */

--- a/apps/web/src/test/handlers/games.ts
+++ b/apps/web/src/test/handlers/games.ts
@@ -2,11 +2,11 @@ import { http, HttpResponse } from "msw";
 
 import type { GradedPly } from "../../games/analysis-contract.ts";
 import {
+  addGames,
   analysisAnswerFor,
-  archiveAccount,
   gameById,
   countWatch,
-  knowsPlayer,
+  pgnImport,
   readArchive,
   seatIdentityFields,
 } from "../archive.ts";
@@ -20,30 +20,49 @@ function positiveInt(value: string | null, fallback: number): number {
   return Number.isInteger(parsed) && parsed >= 1 ? parsed : fallback;
 }
 
-/** Importing and listing are the same read; 400/404 match the route, so the UI fails on its own terms rather than the test peeking at the request. */
+/** The unified library read; 400 matches the route, so the UI fails on its own terms rather than the test peeking at the request. */
 export const gamesHandlers = [
   http.get("/api/games", ({ request }) => {
     const query = new URL(request.url).searchParams;
-    const platform = query.get("platform");
-    const username = query.get("username");
-
-    if (!platform || !username) {
+    const outcome = query.get("outcome");
+    if (outcome !== null && !["win", "loss", "draw"].includes(outcome)) {
       return HttpResponse.json({ error: "invalid query" }, { status: 400 });
-    }
-
-    if (!knowsPlayer(platform, username)) {
-      return HttpResponse.json({ error: "archive not found" }, { status: 404 });
     }
 
     const page = readArchive({
       color: query.get("color"),
-      outcome: query.get("outcome"),
+      outcome,
       timeClass: query.get("timeClass"),
       page: positiveInt(query.get("page"), 1),
       pageSize: positiveInt(query.get("pageSize"), DEFAULT_PAGE_SIZE),
     });
 
-    return HttpResponse.json({ account: archiveAccount(), ...page });
+    return HttpResponse.json(page);
+  }),
+
+  /**
+   * The manual upload. A blank body is the route's 400; a staged failure
+   * answers like an unreachable server; success lands the staged games in
+   * the library so a refetch shows them, exactly as the real slice does.
+   */
+  http.post("/api/games/import", async ({ request }) => {
+    const body = (await request.json()) as { pgn?: string; playerName?: string };
+    if (!body.pgn?.trim() || !body.playerName?.trim()) {
+      return HttpResponse.json({ error: "invalid body" }, { status: 400 });
+    }
+
+    if (pgnImport.refuses) {
+      return HttpResponse.json({ error: "import failed" }, { status: 503 });
+    }
+
+    addGames(...pgnImport.incoming);
+    return HttpResponse.json({
+      imported: pgnImport.incoming.length,
+      duplicates: pgnImport.duplicates,
+      rejected: pgnImport.rejected,
+      judged: 0,
+      seeded: 0,
+    });
   }),
 
   http.get("/api/games/:id", ({ params }) => {

--- a/docs/explanation/apps/api.md
+++ b/docs/explanation/apps/api.md
@@ -42,8 +42,15 @@ handle. `POST /accounts/:id/sync` performs an interactive refresh, enforces the
 per-account cooldown, and returns `Retry-After` when called too soon. The worker
 entry point remains available for refresh work no person is waiting on.
 
-Both paths fetch, persist, update candidate repertoires, judge, and seed. They do
-not run Stockfish.
+`POST /games/import` is the manual source: PGN text uploaded without any
+connected account. It normalizes in-request, resolves the named player's seat
+per game, persists with user-scoped conflict-ignore (a duplicate-only upload
+succeeds with counts), and runs the same judge-and-seed tail — never Stockfish.
+`GET /games` is the unified library: one filtered page of every game the caller
+owns across all sources, ownership read straight off `games.user_id`.
+
+All import paths persist, update candidate repertoires, judge, and seed. None of
+them run Stockfish.
 
 ## Analysis and progress
 

--- a/docs/explanation/modules/db.md
+++ b/docs/explanation/modules/db.md
@@ -120,7 +120,8 @@ is a full table scan). The delete policies encode product decisions:
 
 | FK                                       | onDelete | Why                                                                                              |
 | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `games.account_id`                       | set null | untracking an account keeps its games                                                            |
+| `games.user_id`                          | cascade  | a game without an owner is unreadable — ownership is direct, not inferred                        |
+| `games.account_id`                       | set null | untracking an account keeps its games (provenance only, null for manual imports)                 |
 | `tracked_accounts.user_id`               | set null | deleting a user keeps sync data                                                                  |
 | `repertoires.user_id`                    | cascade  | a repertoire without an owner is meaningless                                                     |
 | `repertoire_chapters.repertoire_id`      | cascade  | a chapter without its repertoire is meaningless                                                  |
@@ -164,27 +165,29 @@ runtime coupling). `libs/repertoire` never imports this package; the
 orchestration layer that reads a chapter's PGN and feeds
 `buildRepertoire` lives above both.
 
+## Ownership
+
+Games hang directly from their user (`games.user_id`, not null) — a manual
+PGN import has no account to infer ownership from, so every read scopes on
+the column instead of joining through `tracked_accounts`. The account is
+provenance: which connected handle produced the row.
+
 ## Dedup
 
-Both constraints are scoped to the tracked account, not global: a
-partial unique index on `(account_id, source, external_id) WHERE
-external_id IS NOT NULL` catches every Chess.com/Lichess re-sync for
-free, no hashing, within that account. A table-level unique constraint
-on `(account_id, movetext_hash)` with `NULLS NOT DISTINCT` catches a
-pasted PGN re-pasted with no linked account — Postgres treats `NULL` as
+External-id dedup stays scoped to the tracked account: a partial unique
+index on `(account_id, source, external_id) WHERE external_id IS NOT NULL`
+catches every Chess.com/Lichess re-sync for free, no hashing, within that
+account — and each account still owns an independent copy of whatever it
+imports, so two accounts tracking the same real handle keep both histories.
+A table-level unique constraint on `(user_id, account_id, movetext_hash)`
+with `NULLS NOT DISTINCT` is the PGN half: `NULL` account ids compare equal
+within one user, so re-uploading the same file inserts nothing, while
+another user importing it keeps their own row. Postgres treats `NULL` as
 distinct from itself by default, which would silently defeat this exact
 case without that clause. `saveGames` inserts with a bare
 `onConflictDoNothing()` (no target), which lets one statement satisfy
 both constraints at once, and reads the actual inserted count off what
 Postgres returns rather than pre-selecting to check.
-
-Each tracked account owns a complete, independent copy of whatever it
-imports. Two accounts (any two users, or the same user twice) tracking
-the same real chess.com/Lichess handle each get their own full history
-— dedup only ever happens within one account, never across two. This
-duplicates storage when that happens, deliberately: simple, correct
-isolation over global storage dedup. A `game_accounts` join table is
-the upgrade path if duplication ever becomes a measured problem.
 
 ## Client
 

--- a/docs/how-to/write-a-test.md
+++ b/docs/how-to/write-a-test.md
@@ -54,7 +54,7 @@ Go in through the route. `apps/server/tests/harness.ts` gives you an app
 with a real database behind it.
 
 ```ts
-const response = await harness.app.request("/games?platform=chess_com&username=alice");
+const response = await harness.app.request("/games");
 expect(response.status).toBe(200);
 ```
 

--- a/docs/reference/ingestion.md
+++ b/docs/reference/ingestion.md
@@ -5,6 +5,16 @@ cursors, and game deduplication as they ship today. Architectural reasoning
 lives in `docs/explanation/apps/api.md` and `docs/explanation/modules/db.md`.
 Verify volatile provider details against the live clients and tests.
 
+## Sources
+
+Three sources land in one games table:
+
+- **Chess.com / Lichess** — connected accounts (`tracked_accounts`) with
+  repeated syncs and provider cursors.
+- **PGN** — a manual upload (`POST /games/import`). No account row, no
+  cursor, no sync lifecycle; the same file may be uploaded again at any
+  time. It never runs the engine.
+
 ## Ownership and identity
 
 Chess.com and Lichess handles identify public data; they do not authenticate a
@@ -12,14 +22,22 @@ VelaChess user. A tracked account belongs to the authenticated user and is
 unique by user, platform, and normalized username. Two users may therefore
 track the same public handle with independent cursors and game histories.
 
+Games are owned directly: `games.user_id` is not null and every read scopes on
+it. `games.account_id` is provenance only — which connected handle produced
+the row — and is null for manually imported PGNs. Deleting an account keeps
+its games; deleting a user takes them.
+
 Provider profile metadata is public cache data keyed by platform and username.
 It does not own games, a cursor, or a user identity.
 
-Games remain scoped to their tracked account. Provider identity is unique by
-account, source, and external id when one exists; movetext deduplication is also
-account-scoped. `saveGames` uses conflict-ignore semantics, so a lower inserted
-count is expected deduplication rather than an application error. Current
-constraints live in `libs/infra/db/schema.ts`.
+Provider identity is unique by account, source, and external id when one
+exists — each account owns a complete, independent copy of whatever it
+imports. Movetext deduplication is scoped by `(user_id, account_id)` with
+`nullsNotDistinct`, so a re-import by the same user is a no-op while another
+user importing the very same PGN keeps their own copy. `saveGames` uses
+conflict-ignore semantics, so a lower inserted count is expected deduplication
+rather than an application error. Current constraints live in
+`libs/infra/db/schema.ts`.
 
 ## Synchronization contract
 
@@ -38,6 +56,10 @@ they are never coerced into standard chess.
 
 Import and refresh fetch, persist, extract candidate repertoires, judge by
 replay, and seed from evidence already present. They do not run Stockfish.
+A PGN import shares that same tail — persist, then the
+extract → judge → seed pass — with no fetch half: normalization happens in
+the request, per game, resolving the named player's seat against White/Black
+so one file may mix colors.
 
 ## Provider cursors
 

--- a/e2e/extraction-loop.spec.ts
+++ b/e2e/extraction-loop.spec.ts
@@ -60,11 +60,13 @@ it("extraction loop: games in, book derived, blunder inside the book drilled", a
     json({ platform: "chess_com", username: "looper" }),
   );
   expect(imported.status).toBe(201);
-  const archive = (await (
-    await app.request("/games?platform=chess_com&username=looper")
-  ).json()) as { account: { id: string }; games: unknown[] };
-  expect(archive.games).toHaveLength(3);
-  const account = archive.account;
+  const account = (await imported.json()) as { id: string };
+  const library = (await (await app.request("/games")).json()) as {
+    total: number;
+    games: unknown[];
+  };
+  expect(library.games).toHaveLength(3);
+  expect(library.total).toBe(3);
 
   // 2. Extract the book from the games themselves.
   const extractRes = await app.request(

--- a/e2e/full-loop.spec.ts
+++ b/e2e/full-loop.spec.ts
@@ -80,15 +80,18 @@ it("full loop: HTTP in, worker in the background, a drilled exercise out", async
     json({ platform: "chess_com", username: "looper" }),
   );
   expect(imported.status).toBe(201);
-  const archive = (await (
-    await app.request("/games?platform=chess_com&username=looper")
-  ).json()) as { account: { id: string }; games: { id: string; analyzed: boolean }[] };
-  expect(archive.games).toHaveLength(2);
-  expect(archive.games.every((g) => !g.analyzed)).toBe(true);
+  const account = (await imported.json()) as { id: string };
+  const library = (await (await app.request("/games")).json()) as {
+    total: number;
+    games: { id: string; analyzed: boolean }[];
+  };
+  expect(library.games).toHaveLength(2);
+  expect(library.total).toBe(2);
+  expect(library.games.every((g) => !g.analyzed)).toBe(true);
 
   // 3. Refreshing now is refused: the import synced a moment ago, and the
   //    platforms answer 429 to bursts.
-  const tooSoon = await app.request(`/accounts/${archive.account.id}/sync`, {
+  const tooSoon = await app.request(`/accounts/${account.id}/sync`, {
     method: "POST",
   });
   expect(tooSoon.status).toBe(429);
@@ -103,9 +106,7 @@ it("full loop: HTTP in, worker in the background, a drilled exercise out", async
   };
   expect(judged).toMatchObject({ judged: 2, enqueuedForAnalysis: 0 });
 
-  const games = (await (
-    await app.request(`/accounts/${archive.account.id}/games`)
-  ).json()) as {
+  const games = (await (await app.request(`/accounts/${account.id}/games`)).json()) as {
     id: string;
     judgmentType: string | null;
     analyzed: boolean;

--- a/libs/application/accounts/sync-account/sync-account.ts
+++ b/libs/application/accounts/sync-account/sync-account.ts
@@ -63,7 +63,12 @@ export async function syncAccount(
           opts,
         );
 
-  const { inserted } = await saveGames(db, result.games, { accountId });
+  // Ownership is direct (the account's user); the account rides along as
+  // provenance and dedup scope.
+  const { inserted } = await saveGames(db, result.games, {
+    userId: account.userId,
+    accountId,
+  });
 
   if (result.complete) {
     // Two facts, two writes: where to resume, and that a pass finished.

--- a/libs/application/analysis/get-analysis/tests/drill-summary.test.ts
+++ b/libs/application/analysis/get-analysis/tests/drill-summary.test.ts
@@ -48,6 +48,7 @@ async function gameWith(positions: StoredGradedPly[]): Promise<string> {
   const [game] = await db
     .insert(games)
     .values({
+      userId,
       accountId: account.id,
       source: "lichess",
       whiteName: "player",
@@ -126,10 +127,14 @@ describe("drillSummaryFor", () => {
     expect((await drillSummaryFor(db, gameId)).eligible).toBe(1);
   });
 
-  it("has nothing to offer for a game nobody claimed", async () => {
-    const [orphan] = await db
+  it("offers nothing for an imported game nobody was named in", async () => {
+    // A PGN upload without a player name imports fine — perspective null,
+    // no account provenance. Ownership is direct, so the summary answers
+    // for it instead of treating it as nobody's.
+    const [imported] = await db
       .insert(games)
       .values({
+        userId,
         source: "pgn",
         whiteName: "a",
         blackName: "b",
@@ -140,7 +145,7 @@ describe("drillSummaryFor", () => {
       })
       .returning();
 
-    expect(await drillSummaryFor(db, orphan!.id)).toEqual({
+    expect(await drillSummaryFor(db, imported!.id)).toEqual({
       eligible: 0,
       seeded: 0,
       triaged: true,
@@ -152,6 +157,7 @@ describe("drillSummaryFor", () => {
     const [unanalyzed] = await db
       .insert(games)
       .values({
+        userId,
         accountId: account.id,
         source: "lichess",
         whiteName: "player",

--- a/libs/application/deviations/list-deviations/list-deviations.ts
+++ b/libs/application/deviations/list-deviations/list-deviations.ts
@@ -7,7 +7,7 @@ import { and, desc, eq, exists } from "drizzle-orm";
 import type { Database } from "@velachess/db";
 import { schema } from "@velachess/db";
 
-const { deviations, exerciseSources, games, trackedAccounts } = schema;
+const { deviations, exerciseSources, games } = schema;
 
 /** The deviation table a UI renders: own deviations with the engine
  * verdict, repertoire attribution (snapshots survive deletion), the game
@@ -41,7 +41,6 @@ export async function listDeviationsForUser(db: Database, userId: string) {
     })
     .from(deviations)
     .innerJoin(games, eq(deviations.gameId, games.id))
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
-    .where(and(eq(trackedAccounts.userId, userId), eq(deviations.type, "deviation")))
+    .where(and(eq(games.userId, userId), eq(deviations.type, "deviation")))
     .orderBy(desc(games.playedAt));
 }

--- a/libs/application/games/import-pgn/import-pgn.ts
+++ b/libs/application/games/import-pgn/import-pgn.ts
@@ -1,0 +1,85 @@
+/**
+ * ImportPgn — a manual upload of PGN text into the user's library.
+ *
+ * The third source, and the odd one out by design: Chess.com and Lichess
+ * are connected accounts with cursors and repeated syncs; a PGN file is
+ * an explicit, repeatable paste that creates no account, holds no cursor,
+ * and never runs the engine. What it shares with them is everything
+ * downstream — rows land in the same games table (ownership direct on
+ * the user), and new games feed the same extract → judge → seed pass a
+ * refresh runs.
+ */
+import { importPgn } from "@velachess/platforms";
+import type { Database } from "@velachess/db";
+import { saveGames } from "@velachess/db";
+import type { AnalysisQueue } from "@velachess/queue/ports";
+
+import { ensureCandidateRepertoires } from "../../repertoires/extract-repertoire/extract-repertoire.ts";
+import { judgeGamesForUser } from "../judge-games/judge-games.ts";
+import { triageAndSeed } from "../../drills/seed-exercises/seed-exercises.ts";
+
+/** A single request body is not an archive: ~2MB of PGN is thousands of
+ * games, far past anything one paste should carry. */
+export const MAX_PGN_LENGTH = 2_000_000;
+
+export interface ImportPgnInput {
+  pgn: string;
+  /**
+   * Who these games belong to, as named in the headers. Resolved per
+   * game, so one file may mix White and Black; games without the name on
+   * either side still import, unattributed. Optional — but without it no
+   * game is judgeable, so the frontend asks for it.
+   */
+  playerName?: string | undefined;
+}
+
+export interface ImportPgnOutcome {
+  /** Games written for this user. */
+  imported: number;
+  /** Games this user already had — deduplicated as a no-op, not an error. */
+  duplicates: number;
+  /** Chunks that failed to parse at all. */
+  rejected: number;
+  judged: number;
+  seeded: number;
+}
+
+/**
+ * Normalize every game in the text, persist what parses, then bring the
+ * training pipeline up to date for exactly the rows that landed.
+ *
+ * Idempotent by constraint, not by prechecking: `(user, account,
+ * movetext hash)` makes this user's re-import a no-op while another
+ * user importing the very same file keeps their own copy. No engine is
+ * ever queued here — analysis has one trigger, opening a game.
+ */
+export async function importPgnForUser(
+  db: Database,
+  userId: string,
+  queue: AnalysisQueue,
+  input: ImportPgnInput,
+): Promise<ImportPgnOutcome> {
+  const result = importPgn(input.pgn, { playerName: input.playerName });
+  const { inserted } = await saveGames(db, result.games, { userId });
+
+  let judged = 0;
+  let seeded = 0;
+  if (inserted > 0) {
+    // Same tail as a sync: derived repertoires grow first so the fresh
+    // book judges this pass, judging replays against it, seeding reads
+    // the judgments. All replay — nothing here costs Stockfish.
+    await ensureCandidateRepertoires(db, userId, { newGames: inserted });
+    const outcome = await judgeGamesForUser(db, userId, queue);
+    const triaged = await triageAndSeed(db, userId);
+    judged = outcome.judged;
+    seeded = triaged.seeded;
+  }
+
+  return {
+    imported: inserted,
+    duplicates: result.games.length - inserted,
+    rejected: result.failures.length,
+    judged,
+    seeded,
+  };
+}

--- a/libs/application/games/import-pgn/import-pgn.ts
+++ b/libs/application/games/import-pgn/import-pgn.ts
@@ -18,10 +18,6 @@ import { ensureCandidateRepertoires } from "../../repertoires/extract-repertoire
 import { judgeGamesForUser } from "../judge-games/judge-games.ts";
 import { triageAndSeed } from "../../drills/seed-exercises/seed-exercises.ts";
 
-/** A single request body is not an archive: ~2MB of PGN is thousands of
- * games, far past anything one paste should carry. */
-export const MAX_PGN_LENGTH = 2_000_000;
-
 export interface ImportPgnInput {
   pgn: string;
   /**
@@ -62,24 +58,21 @@ export async function importPgnForUser(
   const result = importPgn(input.pgn, { playerName: input.playerName });
   const { inserted } = await saveGames(db, result.games, { userId });
 
-  let judged = 0;
-  let seeded = 0;
-  if (inserted > 0) {
-    // Same tail as a sync: derived repertoires grow first so the fresh
-    // book judges this pass, judging replays against it, seeding reads
-    // the judgments. All replay — nothing here costs Stockfish.
-    await ensureCandidateRepertoires(db, userId, { newGames: inserted });
-    const outcome = await judgeGamesForUser(db, userId, queue);
-    const triaged = await triageAndSeed(db, userId);
-    judged = outcome.judged;
-    seeded = triaged.seeded;
-  }
+  // Same tail as a sync: derived repertoires grow first so the fresh
+  // book judges this pass, judging replays against it, seeding reads
+  // the judgments. All replay — nothing here costs Stockfish.
+  //
+  // Runs unconditionally (not gated on inserted > 0) so that a retry
+  // after a partial failure still judges games the first pass missed.
+  await ensureCandidateRepertoires(db, userId, { newGames: inserted });
+  const outcome = await judgeGamesForUser(db, userId, queue);
+  const triaged = await triageAndSeed(db, userId);
 
   return {
     imported: inserted,
     duplicates: result.games.length - inserted,
     rejected: result.failures.length,
-    judged,
-    seeded,
+    judged: outcome.judged,
+    seeded: triaged.seeded,
   };
 }

--- a/libs/application/games/judge-games/tests/judge-games.test.ts
+++ b/libs/application/games/judge-games/tests/judge-games.test.ts
@@ -74,6 +74,7 @@ describe("judgeGamesForUser", () => {
     const [game] = await db
       .insert(games)
       .values({
+        userId: user.id,
         accountId: account.id,
         source: "lichess",
         whiteName: "booked",

--- a/libs/application/games/list-games/list-games.ts
+++ b/libs/application/games/list-games/list-games.ts
@@ -1,21 +1,15 @@
 /**
- * ListGames — one page of a tracked handle's archive, filtered.
+ * ListGames — one page of the user's unified library, filtered.
  *
- * A read and nothing but a read: an untracked username answers null
- * ("import it first") rather than creating a connection.
+ * Every game the user owns in one list: synced Chess.com and Lichess
+ * archives next to manually imported PGNs, provenance visible per row
+ * but never deciding what appears here. Ownership is the games table's
+ * own user_id — a read, and nothing but a read.
  */
 import type { Database, GameFilters, GamePage } from "@velachess/db";
-import { findTrackedAccount, listGamesPage } from "@velachess/db";
+import { listGamesPage } from "@velachess/db";
 
-export type Platform = "chess_com" | "lichess";
-
-export interface Archive {
-  account: {
-    id: string;
-    platform: Platform;
-    username: string;
-    lastSyncedAt: Date | null;
-  };
+export interface Library {
   games: Awaited<ReturnType<typeof listGamesPage>>["rows"];
   /** Matching the filters, not the page — the pager needs the whole count. */
   total: number;
@@ -23,32 +17,15 @@ export interface Archive {
   pageSize: number;
 }
 
-/**
- * "Show me this player's games" — a read, and now nothing but a read.
- *
- * Null when the caller does not track this handle: reads no longer
- * create connections or move ownership, so an untracked username is an
- * answer ("import it first"), not a trigger.
- */
-export async function openArchive(
+/** "Show me my games" — every source at once. */
+export async function openLibrary(
   db: Database,
   userId: string,
-  platform: Platform,
-  username: string,
   view: { filters?: GameFilters; page?: GamePage } = {},
-): Promise<Archive | null> {
-  const account = await findTrackedAccount(db, userId, platform, username);
-  if (!account) return null;
-
-  const listed = await listGamesPage(db, account, view.filters, view.page);
+): Promise<Library> {
+  const listed = await listGamesPage(db, userId, view.filters, view.page);
 
   return {
-    account: {
-      id: account.id,
-      platform: account.platform,
-      username: account.username,
-      lastSyncedAt: account.lastSyncedAt,
-    },
     games: listed.rows,
     total: listed.total,
     page: listed.page,

--- a/libs/application/insights/get-insights/queries.ts
+++ b/libs/application/insights/get-insights/queries.ts
@@ -14,7 +14,8 @@ const { games, gameAnalyses, trackedAccounts } = schema;
  * Oldest first, because the trend source windows over time. The analysis
  * rides along as a left join — a game without one still counts for
  * results and openings, and its `plies` are honestly null rather than
- * empty.
+ * empty. So does the provenance account: a synced game needs its
+ * username for perspective derivation; a PGN import has none and stays.
  */
 export async function listInsightGames(
   db: Database,
@@ -37,9 +38,9 @@ export async function listInsightGames(
       positions: gameAnalyses.positions,
     })
     .from(games)
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
+    .leftJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
     .leftJoin(gameAnalyses, eq(gameAnalyses.gameId, games.id))
-    .where(eq(trackedAccounts.userId, userId))
+    .where(eq(games.userId, userId))
     .orderBy(asc(games.playedAt), asc(games.id));
 
   return rows.map((row) => ({

--- a/libs/application/insights/get-insights/tests/get-insights.test.ts
+++ b/libs/application/insights/get-insights/tests/get-insights.test.ts
@@ -56,6 +56,7 @@ beforeAll(async () => {
     const [game] = await harness.db
       .insert(schema.games)
       .values({
+        userId,
         accountId: account.id,
         source: "chess_com",
         perspective: null,

--- a/libs/application/overview/get-overview/get-overview.ts
+++ b/libs/application/overview/get-overview/get-overview.ts
@@ -8,21 +8,19 @@ import { and, count, eq, lte } from "drizzle-orm";
 import type { Database } from "@velachess/db";
 import { schema } from "@velachess/db";
 
-const { cards, deviations, exercises, games, trackedAccounts } = schema;
+const { cards, deviations, exercises, games } = schema;
 
 /** One-call counters for the stats endpoint — no N queries from HTTP. */
 export async function getOverview(db: Database, userId: string, now: Date = new Date()) {
   const [gamesRow] = await db
     .select({ n: count() })
     .from(games)
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
-    .where(eq(trackedAccounts.userId, userId));
+    .where(eq(games.userId, userId));
   const [deviationsRow] = await db
     .select({ n: count() })
     .from(deviations)
     .innerJoin(games, eq(deviations.gameId, games.id))
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
-    .where(eq(trackedAccounts.userId, userId));
+    .where(eq(games.userId, userId));
   const [exercisesRow] = await db
     .select({ n: count() })
     .from(exercises)

--- a/libs/application/perspective.ts
+++ b/libs/application/perspective.ts
@@ -1,8 +1,9 @@
 /**
- * Which side is "you" in a game. Stored perspective wins (pasted PGNs can
- * declare it); synced games derive it from the tracked account username
- * vs the player names — the normalizer can't know who "you" are, the
- * tracked account can. Null = not determinable, not judgeable.
+ * Which side is "you" in a game. Stored perspective wins (a manual PGN
+ * import resolved it per game); synced games derive it from the tracked
+ * account username vs the player names — the normalizer can't know who
+ * "you" are, the tracked account can. Null = not determinable, not
+ * judgeable.
  */
 
 export interface PerspectiveSource {
@@ -10,7 +11,8 @@ export interface PerspectiveSource {
   perspective: string | null;
   whiteName: string;
   blackName: string;
-  accountUsername: string;
+  /** Absent on manually imported games — there is no handle behind them. */
+  accountUsername: string | null;
 }
 
 export function resolveGamePerspective(
@@ -18,7 +20,8 @@ export function resolveGamePerspective(
 ): "white" | "black" | null {
   if (game.perspective === "white" || game.perspective === "black")
     return game.perspective;
-  const username = game.accountUsername.toLowerCase();
+  const username = game.accountUsername?.toLowerCase();
+  if (!username) return null;
   if (game.whiteName.toLowerCase() === username) return "white";
   if (game.blackName.toLowerCase() === username) return "black";
   return null;

--- a/libs/application/tests/application.test.ts
+++ b/libs/application/tests/application.test.ts
@@ -7,6 +7,7 @@ import { makeScheduler } from "@velachess/scheduler";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import type { Database } from "@velachess/db";
+import type { GameFilters, GamePage } from "@velachess/db";
 import {
   addChapter,
   countDrillQueue,
@@ -35,7 +36,7 @@ import { getReviewItem } from "../drills/get-next-drill/get-next-drill.ts";
 import { triageAndSeed } from "../drills/seed-exercises/seed-exercises.ts";
 import { submitAnswer } from "../drills/submit-answer/submit-answer.ts";
 import { judgeGamesForUser } from "../games/judge-games/judge-games.ts";
-import { openArchive } from "../games/list-games/list-games.ts";
+import { openLibrary } from "../games/list-games/list-games.ts";
 import {
   REPERTOIRE_NAME,
   extractRepertoire,
@@ -76,16 +77,18 @@ describe("application services (the flow, end to end)", () => {
 
   /**
    * Import (idempotent — first contact fills, later calls are no-ops)
-   * then read: the two halves of what openArchive used to be before
-   * reads stopped creating connections.
+   * then read the unified library: the write half and the read half of
+   * what one function used to do before reads stopped creating
+   * connections.
    */
   async function openImported(
     username: string,
-    view: Parameters<typeof openArchive>[4] = {},
+    view: { filters?: GameFilters; page?: GamePage } = {},
     deps: Parameters<typeof importAccount>[4] = {},
+    ownerId: string = userId,
   ) {
-    await importAccount(h.db, userId, "chess_com", username, deps);
-    return (await openArchive(h.db, userId, "chess_com", username, view))!;
+    const account = await importAccount(h.db, ownerId, "chess_com", username, deps);
+    return { account, library: await openLibrary(h.db, ownerId, view) };
   }
 
   it("a user anchors the flow", async () => {
@@ -206,6 +209,7 @@ describe("application services (the flow, end to end)", () => {
     const [game] = await h.db
       .insert(games)
       .values({
+        userId,
         source: "pgn",
         whiteName: "w",
         blackName: "b",
@@ -380,9 +384,9 @@ describe("application services (the flow, end to end)", () => {
     expect(cached.engineCategory).not.toBeNull();
   });
 
-  it("openArchive: a first read fills the account, a second one only reads", async () => {
-    // Its own movetext: games dedupe globally by hash, so reusing the
-    // looper fixture here would save nothing and prove nothing.
+  it("importAccount: a first import fills the archive, a second one only reads", async () => {
+    // Its own movetext: games dedupe per user and account, so reusing
+    // the looper fixture here would save nothing and prove nothing.
     const freshArchive: typeof fetch = (async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith("/archives")) {
@@ -408,30 +412,40 @@ describe("application services (the flow, end to end)", () => {
       });
     }) as typeof fetch;
 
-    const archive = await openImported("Fresh_Import", {}, { fetch: freshArchive });
+    // The unified library is per user — a fresh one, so these
+    // assertions see exactly this import and nothing earlier in the
+    // suite.
+    const ownerId = (await createUser(h.db)).id;
+    const { account, library } = await openImported(
+      "Fresh_Import",
+      {},
+      { fetch: freshArchive },
+      ownerId,
+    );
 
     // Username normalised on the way in, games listed with status.
-    expect(archive.account.username).toBe("fresh_import");
-    expect(archive.account.lastSyncedAt).not.toBeNull();
-    expect(archive.games.length).toBe(2);
+    expect(account.username).toBe("fresh_import");
+    expect(account.lastSyncedAt).not.toBeNull();
+    expect(library.games.length).toBe(2);
 
-    // Which side was you is DERIVED, not stored: the normalizer sees a PGN
-    // and no identity, so `games.perspective` is null on everything synced.
-    // Without this the list called every game unfinished and drew every
-    // player white. The fixture has one game from each seat.
-    const bySeat = Object.fromEntries(archive.games.map((g) => [g.perspective, g]));
+    // Which side was you is DERIVED for synced games, not stored: the
+    // normalizer sees a PGN and no identity, so `games.perspective` is
+    // null on everything synced. Without this derivation the list called
+    // every game unfinished and drew every player white. The fixture has
+    // one game from each seat.
+    const bySeat = Object.fromEntries(library.games.map((g) => [g.perspective, g]));
     expect(Object.keys(bySeat).toSorted()).toEqual(["black", "white"]);
     expect(bySeat.white!.whiteName).toBe("fresh_import");
     expect(bySeat.black!.blackName).toBe("fresh_import");
 
     // Importing runs no engine. Judging is replay and analysis is intent —
     // an archive of hundreds of games must not queue hundreds of runs.
-    for (const game of archive.games) {
+    for (const game of library.games) {
       expect(await h.analysisQueue.getState(game.id)).toBe("none");
       expect(game.analyzed).toBe(false);
     }
 
-    // Second read never pulls the archive again: a fetch that would throw
+    // Second import never pulls the archive again: a fetch that would throw
     // on any game request. The profile endpoint is answered instead of
     // throwing — a re-import still refreshes identity by design — and
     // returning no avatar keeps what was stored.
@@ -447,29 +461,32 @@ describe("application services (the flow, end to end)", () => {
           throw new Error("the archive was already filled");
         }) as unknown as typeof fetch,
       },
+      ownerId,
     );
-    expect(again.account.id).toBe(archive.account.id);
-    expect(again.games.length).toBe(2);
+    expect(again.account.id).toBe(account.id);
+    expect(again.library.games.length).toBe(2);
   });
 
-  it("openArchive: every field the games list renders survives the trip", async () => {
+  it("the library list: every field the games list renders survives the trip", async () => {
     // The contract test the list never had. Its columns read ratings, a
     // clock, an opening and a platform link — none of which the judging
     // fixtures carry, so a green suite said nothing about whether the
     // pipeline delivers them. This archive is tagged like a real one.
-    const archive = await openImported(
+    const { library } = await openImported(
       LISTER_USERNAME,
       {},
       { fetch: chessComListingFixtureFetch() },
+      // Same isolation: this user's library holds only what it imports.
+      (await createUser(h.db)).id,
     );
 
-    expect(archive.games).toHaveLength(2);
-    const asWhite = archive.games.find((game) => game.perspective === "white")!;
-    const asBlack = archive.games.find((game) => game.perspective === "black")!;
+    expect(library.games).toHaveLength(2);
+    const asWhite = library.games.find((game) => game.perspective === "white")!;
+    const asBlack = library.games.find((game) => game.perspective === "black")!;
     expect(asWhite).toBeDefined();
     expect(asBlack).toBeDefined();
 
-    for (const game of archive.games) {
+    for (const game of library.games) {
       expect(game.whiteRating, "white rating").not.toBeNull();
       expect(game.blackRating, "black rating").not.toBeNull();
       expect(game.playedAt, "played at").not.toBeNull();
@@ -489,55 +506,52 @@ describe("application services (the flow, end to end)", () => {
     expect(asBlack.timeControlIncrementSeconds).toBe(2);
   });
 
-  it("openArchive: filtering by outcome reads the derived seat, not the stored column", async () => {
+  it("library filters read the derived seat, not the stored column", async () => {
     // The filter and the column have to agree. Pointed at the stored
     // `perspective` (null on everything synced) this returns nothing while
     // the list happily shows wins.
-    const won = await openImported(
+    const ownerId = (await createUser(h.db)).id;
+    await openImported(
       LISTER_USERNAME,
-      { filters: { outcome: "win" } },
+      {},
       { fetch: chessComListingFixtureFetch() },
+      ownerId,
     );
+
+    const won = await openLibrary(h.db, ownerId, { filters: { outcome: "win" } });
     expect(won.games).toHaveLength(1);
     expect(won.games[0]!.perspective).toBe("white");
     expect(won.total).toBe(1);
 
-    const lost = await openImported(
-      LISTER_USERNAME,
-      { filters: { outcome: "loss" } },
-      { fetch: chessComListingFixtureFetch() },
-    );
+    const lost = await openLibrary(h.db, ownerId, { filters: { outcome: "loss" } });
     expect(lost.games).toHaveLength(1);
     expect(lost.games[0]!.perspective).toBe("black");
 
-    const asBlack = await openImported(
-      LISTER_USERNAME,
-      { filters: { color: "black" } },
-      { fetch: chessComListingFixtureFetch() },
-    );
+    const asBlack = await openLibrary(h.db, ownerId, { filters: { color: "black" } });
     expect(asBlack.games).toHaveLength(1);
 
     // 10 min is rapid; 3+2 estimates to 300s, which is blitz.
-    const blitz = await openImported(
-      LISTER_USERNAME,
-      { filters: { timeClass: "blitz" } },
-      { fetch: chessComListingFixtureFetch() },
-    );
+    const blitz = await openLibrary(h.db, ownerId, { filters: { timeClass: "blitz" } });
     expect(blitz.games).toHaveLength(1);
     expect(blitz.games[0]!.timeControlInitialSeconds).toBe(180);
   });
 
-  it("openArchive: a page is a slice of the whole, and total ignores it", async () => {
-    const first = await openImported(
+  it("a page is a slice of the whole, and total ignores it", async () => {
+    // Fresh owner again: the pager's totals must count one import, not
+    // everything the suite has accumulated.
+    const ownerId = (await createUser(h.db)).id;
+    await openImported(
       LISTER_USERNAME,
-      { page: { page: 1, pageSize: 1 } },
+      {},
       { fetch: chessComListingFixtureFetch() },
+      ownerId,
     );
-    const second = await openImported(
-      LISTER_USERNAME,
-      { page: { page: 2, pageSize: 1 } },
-      { fetch: chessComListingFixtureFetch() },
-    );
+    const first = await openLibrary(h.db, ownerId, {
+      page: { page: 1, pageSize: 1 },
+    });
+    const second = await openLibrary(h.db, ownerId, {
+      page: { page: 2, pageSize: 1 },
+    });
 
     expect(first.games).toHaveLength(1);
     expect(second.games).toHaveLength(1);
@@ -670,6 +684,7 @@ describe("the repertoire → deviations → training loop", () => {
     const [gapGame] = await loop.db
       .insert(games)
       .values({
+        userId,
         accountId,
         source: "chess_com",
         perspective: null,
@@ -683,6 +698,7 @@ describe("the repertoire → deviations → training loop", () => {
       })
       .returning();
     await loop.db.insert(games).values({
+      userId,
       accountId,
       source: "chess_com",
       perspective: null,
@@ -818,6 +834,7 @@ describe("the repertoire → deviations → training loop", () => {
 
     // A NEW game fails the same prepared position (2.h4 instead of d4).
     await loop.db.insert(games).values({
+      userId,
       accountId,
       source: "chess_com",
       perspective: null,

--- a/libs/fixtures/games.ts
+++ b/libs/fixtures/games.ts
@@ -170,3 +170,51 @@ export const PROMOTION_DEVIATION_GAME_PGN = `[Event "Promotion deviation"]
 
 1. e8=N *
 `;
+
+/**
+ * The player a manual import names as theirs — one person, both colors
+ * across the file. Invented handle; a test has no business shipping a
+ * real player's name.
+ */
+export const IMPORTED_PLAYER_NAME = "Ada Lovelace";
+
+/**
+ * One upload, two games, opposite seats: the named player is White in
+ * the first and Black in the second, so per-game perspective resolution
+ * has something honest to resolve.
+ */
+export const MIXED_COLOR_PGN = `[Event "As white"]
+[Site "?"]
+[White "${IMPORTED_PLAYER_NAME}"]
+[Black "Invented Opponent"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 *
+[Event "As black"]
+[Site "?"]
+[White "Invented Opponent"]
+[Black "${IMPORTED_PLAYER_NAME}"]
+[Result "*"]
+
+1. d4 d5 2. c4 e6 *
+`;
+
+/** RUY_LOPEZ_REPERTOIRE_PGN's mainline, tagged with real player names so a manual import can attribute it. */
+export const NAMED_IN_BOOK_GAME_PGN = `[Event "Named in book"]
+[Site "?"]
+[White "${IMPORTED_PLAYER_NAME}"]
+[Black "Marcel Duchamp"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 *
+`;
+
+/** The named player leaves the book at move 4: Bc4 instead of Ba4. */
+export const NAMED_DEVIATION_GAME_PGN = `[Event "Named deviation"]
+[Site "?"]
+[White "${IMPORTED_PLAYER_NAME}"]
+[Black "Marcel Duchamp"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Bc4 *
+`;

--- a/libs/infra/db/migrations/0019_direct_game_ownership.sql
+++ b/libs/infra/db/migrations/0019_direct_game_ownership.sql
@@ -1,0 +1,16 @@
+-- Direct ownership: games hang from their user, not from a tracked
+-- account. A manual PGN import has no account to infer ownership from,
+-- so the column must exist before any PGN row does. Existing rows adopt
+-- their account's owner; a game without an account cannot exist yet.
+ALTER TABLE "games" DROP CONSTRAINT "games_account_movetext";--> statement-breakpoint
+ALTER TABLE "games" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+UPDATE "games"
+SET "user_id" = "tracked_accounts"."user_id"
+FROM "tracked_accounts"
+WHERE "games"."account_id" = "tracked_accounts"."id";--> statement-breakpoint
+ALTER TABLE "games" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "games_user_played_at" ON "games" USING btree ("user_id","played_at" DESC NULLS LAST);--> statement-breakpoint
+-- Movetext dedup becomes user-scoped: one user's re-import of the same
+-- PGN is a no-op, another user's import of it keeps its own row.
+ALTER TABLE "games" ADD CONSTRAINT "games_user_account_movetext" UNIQUE NULLS NOT DISTINCT("user_id","account_id","movetext_hash");

--- a/libs/infra/db/migrations/meta/0019_snapshot.json
+++ b/libs/infra/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2074 @@
+{
+  "id": "8adf95bf-63cc-4386-8ad3-00a485632c3c",
+  "prevId": "a88845ca-77db-4cdc-8be0-3fede37ad436",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_progress": {
+      "name": "analysis_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_progress_run_index": {
+          "name": "analysis_progress_run_index",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_progress_game_seq": {
+          "name": "analysis_progress_game_seq",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_progress_game_id_games_id_fk": {
+          "name": "analysis_progress_game_id_games_id_fk",
+          "tableFrom": "analysis_progress",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_accounts_user_id": {
+          "name": "auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_accounts_provider_account": {
+          "name": "auth_accounts_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_users_id_fk": {
+          "name": "auth_accounts_user_id_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_rate_limits_key_unique": {
+          "name": "auth_rate_limits_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due": {
+          "name": "due",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stability": {
+          "name": "stability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elapsed_days": {
+          "name": "elapsed_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_days": {
+          "name": "scheduled_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "learning_steps": {
+          "name": "learning_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phase": {
+          "name": "phase",
+          "type": "card_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_review": {
+          "name": "last_review",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cards_exercise_id": {
+          "name": "cards_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cards_due": {
+          "name": "cards_due",
+          "columns": [
+            {
+              "expression": "due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cards_exercise_id_exercises_id_fk": {
+          "name": "cards_exercise_id_exercises_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deviations": {
+      "name": "deviations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repertoire_name_snapshot": {
+          "name": "repertoire_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_name_snapshot": {
+          "name": "chapter_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "deviation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_book_plies": {
+          "name": "in_book_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_plies": {
+          "name": "game_plies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played_san": {
+          "name": "played_san",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cp_loss": {
+          "name": "cp_loss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_category": {
+          "name": "engine_category",
+          "type": "engine_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drillable": {
+          "name": "drillable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deviations_game_repertoire": {
+          "name": "deviations_game_repertoire",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_repertoire_id": {
+          "name": "deviations_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deviations_chapter_id": {
+          "name": "deviations_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deviations_game_id_games_id_fk": {
+          "name": "deviations_game_id_games_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deviations_repertoire_id_repertoires_id_fk": {
+          "name": "deviations_repertoire_id_repertoires_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deviations_chapter_id_repertoire_chapters_id_fk": {
+          "name": "deviations_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "deviations",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_responses": {
+      "name": "training_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "training_grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "training_responses_exercise_id": {
+          "name": "training_responses_exercise_id",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_responses_exercise_id_exercises_id_fk": {
+          "name": "training_responses_exercise_id_exercises_id_fk",
+          "tableFrom": "training_responses",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_sources": {
+      "name": "exercise_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "drill_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviation_id": {
+          "name": "deviation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ply": {
+          "name": "ply",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "exercise_sources_deviation": {
+          "name": "exercise_sources_deviation",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"deviation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_ply": {
+          "name": "exercise_sources_ply",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"game_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter": {
+          "name": "exercise_sources_chapter",
+          "columns": [
+            {
+              "expression": "exercise_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exercise_sources\".\"chapter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_deviation_id": {
+          "name": "exercise_sources_deviation_id",
+          "columns": [
+            {
+              "expression": "deviation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_game_id": {
+          "name": "exercise_sources_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercise_sources_chapter_id": {
+          "name": "exercise_sources_chapter_id",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_sources_exercise_id_exercises_id_fk": {
+          "name": "exercise_sources_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "exercises",
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_deviation_id_deviations_id_fk": {
+          "name": "exercise_sources_deviation_id_deviations_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "deviations",
+          "columnsFrom": ["deviation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_game_id_games_id_fk": {
+          "name": "exercise_sources_game_id_games_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_sources_chapter_id_repertoire_chapters_id_fk": {
+          "name": "exercise_sources_chapter_id_repertoire_chapters_id_fk",
+          "tableFrom": "exercise_sources",
+          "tableTo": "repertoire_chapters",
+          "columnsFrom": ["chapter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exercise_sources_origin_shape": {
+          "name": "exercise_sources_origin_shape",
+          "value": "(\"exercise_sources\".\"origin\" = 'repertoire-deviation'\n             AND \"exercise_sources\".\"deviation_id\" IS NOT NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'engine-blunder'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NOT NULL AND \"exercise_sources\".\"ply\" IS NOT NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NULL)\n          OR (\"exercise_sources\".\"origin\" = 'repertoire-line'\n             AND \"exercise_sources\".\"deviation_id\" IS NULL\n             AND \"exercise_sources\".\"game_id\" IS NULL AND \"exercise_sources\".\"ply\" IS NULL\n             AND \"exercise_sources\".\"chapter_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_key": {
+          "name": "position_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_sans": {
+          "name": "expected_sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exercises_user_position": {
+          "name": "exercises_user_position",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exercises_user_id": {
+          "name": "exercises_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_analyses": {
+      "name": "game_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine_version": {
+          "name": "engine_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "positions": {
+          "name": "positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_analyses_game_id": {
+          "name": "game_analyses_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_analyses_game_id_games_id_fk": {
+          "name": "game_analyses_game_id_games_id_fk",
+          "tableFrom": "game_analyses",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "game_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perspective": {
+          "name": "perspective",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "white_name": {
+          "name": "white_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "white_rating": {
+          "name": "white_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "black_name": {
+          "name": "black_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "black_rating": {
+          "name": "black_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "game_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_initial_seconds": {
+          "name": "time_control_initial_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_increment_seconds": {
+          "name": "time_control_increment_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_control_raw": {
+          "name": "time_control_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_eco": {
+          "name": "opening_eco",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_name": {
+          "name": "opening_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_url": {
+          "name": "opening_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination": {
+          "name": "termination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_clocks": {
+          "name": "has_clocks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_pgn": {
+          "name": "raw_pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movetext_hash": {
+          "name": "movetext_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "games_account_source_external_id": {
+          "name": "games_account_source_external_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"games\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_user_played_at": {
+          "name": "games_user_played_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_account_played_at": {
+          "name": "games_account_played_at",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_user_id_users_id_fk": {
+          "name": "games_user_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_account_id_tracked_accounts_id_fk": {
+          "name": "games_account_id_tracked_accounts_id_fk",
+          "tableFrom": "games",
+          "tableTo": "tracked_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_user_account_movetext": {
+          "name": "games_user_account_movetext",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "account_id", "movetext_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_profiles": {
+      "name": "provider_profiles",
+      "schema": "",
+      "columns": {
+        "platform": {
+          "name": "platform",
+          "type": "platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flair": {
+          "name": "flair",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_profiles_platform_username": {
+          "name": "provider_profiles_platform_username",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoire_chapters": {
+      "name": "repertoire_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repertoire_id": {
+          "name": "repertoire_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pgn": {
+          "name": "pgn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting_fen": {
+          "name": "starting_fen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoire_chapters_repertoire_id": {
+          "name": "repertoire_chapters_repertoire_id",
+          "columns": [
+            {
+              "expression": "repertoire_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoire_chapters_repertoire_id_repertoires_id_fk": {
+          "name": "repertoire_chapters_repertoire_id_repertoires_id_fk",
+          "tableFrom": "repertoire_chapters",
+          "tableTo": "repertoires",
+          "columnsFrom": ["repertoire_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repertoire_chapters_repertoire_sort": {
+          "name": "repertoire_chapters_repertoire_sort",
+          "nullsNotDistinct": false,
+          "columns": ["repertoire_id", "sort_order"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repertoires": {
+      "name": "repertoires",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "perspective",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "repertoire_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repertoires_user_id": {
+          "name": "repertoires_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repertoires_user_id_users_id_fk": {
+          "name": "repertoires_user_id_users_id_fk",
+          "tableFrom": "repertoires",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id": {
+          "name": "sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_accounts": {
+      "name": "tracked_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_accounts_user_platform_username": {
+          "name": "tracked_accounts_user_platform_username",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tracked_accounts_user_id": {
+          "name": "tracked_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracked_accounts_user_id_users_id_fk": {
+          "name": "tracked_accounts_user_id_users_id_fk",
+          "tableFrom": "tracked_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier": {
+          "name": "verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.card_phase": {
+      "name": "card_phase",
+      "schema": "public",
+      "values": ["new", "learning", "review", "relearning"]
+    },
+    "public.deviation_type": {
+      "name": "deviation_type",
+      "schema": "public",
+      "values": ["deviation", "gap", "book-ended", "completed", "unmatched"]
+    },
+    "public.training_grade": {
+      "name": "training_grade",
+      "schema": "public",
+      "values": ["again", "hard", "good", "easy"]
+    },
+    "public.drill_origin": {
+      "name": "drill_origin",
+      "schema": "public",
+      "values": ["repertoire-deviation", "engine-blunder", "repertoire-line"]
+    },
+    "public.engine_category": {
+      "name": "engine_category",
+      "schema": "public",
+      "values": ["ok", "inaccuracy", "mistake", "blunder"]
+    },
+    "public.game_source": {
+      "name": "game_source",
+      "schema": "public",
+      "values": ["chess_com", "lichess", "pgn"]
+    },
+    "public.perspective": {
+      "name": "perspective",
+      "schema": "public",
+      "values": ["white", "black"]
+    },
+    "public.platform": {
+      "name": "platform",
+      "schema": "public",
+      "values": ["chess_com", "lichess"]
+    },
+    "public.repertoire_source": {
+      "name": "repertoire_source",
+      "schema": "public",
+      "values": ["manual", "extracted"]
+    },
+    "public.game_result": {
+      "name": "game_result",
+      "schema": "public",
+      "values": ["1-0", "0-1", "1/2-1/2", "*"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/infra/db/migrations/meta/_journal.json
+++ b/libs/infra/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1787613237066,
       "tag": "0018_provider_profiles",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1787691357145,
+      "tag": "0019_direct_game_ownership",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/infra/db/queries/engine-drills.ts
+++ b/libs/infra/db/queries/engine-drills.ts
@@ -49,12 +49,12 @@ export async function listEngineDrillCandidates(
     })
     .from(gameAnalyses)
     .innerJoin(games, eq(gameAnalyses.gameId, games.id))
-    // Inner join, not left: a game with no tracked account has no "you",
-    // and there is nobody to attribute the mistake to.
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
+    // Provenance only — the fallback for perspective when the game
+    // stores none. A PGN import has no account and still owns its games.
+    .leftJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
     .where(
       and(
-        eq(trackedAccounts.userId, userId),
+        eq(games.userId, userId),
         opts.gameId ? eq(gameAnalyses.gameId, opts.gameId) : undefined,
       ),
     );
@@ -101,40 +101,40 @@ async function seededPliesByGame(
 }
 
 /**
- * Stored perspective wins; otherwise the tracked username decides. Same
- * rule as `resolveGamePerspective` in application, restated rather than
- * imported — importing it would invert the persistence/application
- * dependency the architecture tests protect. Acceptance test pins both.
+ * Stored perspective wins; otherwise the provenance account's username
+ * decides, when there is one. Same rule as `resolveGamePerspective` in
+ * application, restated rather than imported — importing it would invert
+ * the persistence/application dependency the architecture tests protect.
+ * Acceptance test pins both.
  */
 function sideOfUser(row: {
   perspective: string | null;
   whiteName: string;
   blackName: string;
-  accountUsername: string;
+  accountUsername: string | null;
 }): "white" | "black" | null {
   if (row.perspective === "white" || row.perspective === "black") {
     return row.perspective;
   }
-  const username = row.accountUsername.toLowerCase();
+  const username = row.accountUsername?.toLowerCase();
+  if (!username) return null;
   if (row.whiteName.toLowerCase() === username) return "white";
   if (row.blackName.toLowerCase() === username) return "black";
   return null;
 }
 
 /**
- * Who a game belongs to, for callers holding only a game id.
- *
- * Null when the game has no tracked account — a pasted PGN nobody
- * claimed. Nothing downstream can be attributed to a person then.
+ * Who a game belongs to — the row's own owner. Null only for a game id
+ * that does not exist; ownership is no longer inferred through an
+ * account, so a manually imported PGN answers exactly like a synced one.
  */
 export async function userIdForGame(
   db: Database,
   gameId: string,
 ): Promise<string | null> {
   const [row] = await db
-    .select({ userId: trackedAccounts.userId })
+    .select({ userId: games.userId })
     .from(games)
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
     .where(eq(games.id, gameId))
     .limit(1);
 

--- a/libs/infra/db/queries/games.ts
+++ b/libs/infra/db/queries/games.ts
@@ -1,11 +1,12 @@
 import type { NormalizedGame } from "@velachess/platforms";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, type SQL } from "drizzle-orm";
 
 import type { Database } from "../client.ts";
-import { games, trackedAccounts } from "../schema.ts";
+import { games } from "../schema.ts";
 
-function toRow(game: NormalizedGame, accountId: string | undefined) {
+function toRow(game: NormalizedGame, userId: string, accountId: string | undefined) {
   return {
+    userId,
     source: game.source,
     externalId: game.externalId,
     externalUrl: game.externalUrl,
@@ -30,16 +31,23 @@ function toRow(game: NormalizedGame, accountId: string | undefined) {
   };
 }
 
+/**
+ * Conflict-ignore persistence: a blocked insert is deduplication, not an
+ * error — the caller reads it from the lower inserted count. Ownership is
+ * always the user's; `accountId` is provenance only (a manual PGN import
+ * has none), and the unique constraints decide what "duplicate" means per
+ * source.
+ */
 export async function saveGames(
   db: Database,
   normalizedGames: NormalizedGame[],
-  opts: { accountId?: string } = {},
+  opts: { userId: string; accountId?: string },
 ): Promise<{ inserted: number }> {
   if (normalizedGames.length === 0) return { inserted: 0 };
 
   const inserted = await db
     .insert(games)
-    .values(normalizedGames.map((game) => toRow(game, opts.accountId)))
+    .values(normalizedGames.map((game) => toRow(game, opts.userId, opts.accountId)))
     .onConflictDoNothing()
     .returning({ id: games.id });
 
@@ -75,16 +83,21 @@ const gameListColumns = {
 
 export async function listGames(
   db: Database,
-  opts: { accountId?: string; limit?: number; offset?: number } = {},
+  opts: { userId?: string; accountId?: string; limit?: number; offset?: number } = {},
 ) {
+  const scopes: SQL[] = [];
+  if (opts.userId) scopes.push(eq(games.userId, opts.userId));
+  if (opts.accountId) scopes.push(eq(games.accountId, opts.accountId));
+
   const query = db
     .select(gameListColumns)
     .from(games)
+    .where(scopes.length > 0 ? and(...scopes) : undefined)
     .orderBy(desc(games.playedAt))
     .limit(opts.limit ?? 50)
     .offset(opts.offset ?? 0);
 
-  return opts.accountId ? query.where(eq(games.accountId, opts.accountId)) : query;
+  return query;
 }
 
 /**
@@ -98,16 +111,16 @@ export async function getGame(db: Database, gameId: string) {
 }
 
 /**
- * The full row, only if the caller owns it — ownership rides through
- * `games.account_id → tracked_accounts.user_id`, scoped in the query
- * rather than checked after the fetch, so there is no window where the
- * row exists in memory for a caller it does not belong to.
+ * The full row, only if the caller owns it. Ownership is the row's own
+ * `user_id` — no join, so a manually imported PGN is scoped exactly like
+ * a synced game, and the check happens in the query rather than after
+ * the fetch: there is no window where the row exists in memory for a
+ * caller it does not belong to.
  */
 export async function getGameForUser(db: Database, userId: string, gameId: string) {
   const [row] = await db
-    .select({ game: games })
+    .select()
     .from(games)
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
-    .where(and(eq(games.id, gameId), eq(trackedAccounts.userId, userId)));
-  return row?.game ?? null;
+    .where(and(eq(games.id, gameId), eq(games.userId, userId)));
+  return row ?? null;
 }

--- a/libs/infra/db/queries/repertoire-stats.ts
+++ b/libs/infra/db/queries/repertoire-stats.ts
@@ -8,7 +8,7 @@
 import { and, count, desc, eq, max, notExists, sql } from "drizzle-orm";
 
 import type { Database } from "../client.ts";
-import { deviations, games, repertoireChapters, trackedAccounts } from "../schema.ts";
+import { deviations, games, repertoireChapters } from "../schema.ts";
 
 /** Judgment rows per outcome type, one count each. */
 export async function countJudgmentsByType(db: Database, repertoireId: string) {
@@ -97,10 +97,9 @@ export async function countUnjudgedGames(db: Database, userId: string) {
   const [row] = await db
     .select({ n: count() })
     .from(games)
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
     .where(
       and(
-        eq(trackedAccounts.userId, userId),
+        eq(games.userId, userId),
         notExists(
           db
             .select({ one: deviations.id })

--- a/libs/infra/db/queries/status.ts
+++ b/libs/infra/db/queries/status.ts
@@ -26,23 +26,20 @@ export interface GamePage {
   pageSize: number;
 }
 
-/** The username is not decoration: it is how "you" is resolved. */
-export interface GameAccount {
-  id: string;
-  username: string;
-}
-
 /**
- * Which side was you. `games.perspective` is null for synced games (the
- * normalizer sees a PGN, not an identity), so this derives it by matching
- * the tracked username against player names — same rule as
- * `resolveGamePerspective` — instead of backfilling a column.
+ * Which side was you. `games.perspective` carries what a manual PGN
+ * import resolved; synced games store null (the normalizer sees a PGN,
+ * not an identity), so this derives it by matching the provenance
+ * account's username against player names — same rule as
+ * `resolveGamePerspective`. The account join is a LEFT join and may be
+ * absent (a PGN row has none): a NULL username makes both comparisons
+ * NULL, so such games answer from the stored column alone or stay null.
  */
-const perspectiveSql = (username: string) => sql<"white" | "black" | null>`coalesce(
+const perspectiveSql = sql<"white" | "black" | null>`coalesce(
   ${games.perspective}::text,
   case
-    when lower(${games.whiteName}) = lower(${username}) then 'white'
-    when lower(${games.blackName}) = lower(${username}) then 'black'
+    when lower(${games.whiteName}) = lower(${trackedAccounts.username}) then 'white'
+    when lower(${games.blackName}) = lower(${trackedAccounts.username}) then 'black'
   end
 )`;
 
@@ -68,27 +65,30 @@ function timeClassPredicate(timeClass: TimeClass): SQL {
 
 /**
  * Won, lost or drew — from your seat. The scoresheet says "1-0"; whether
- * that is a win depends on which side you were, so the two columns have to
- * be read together.
+ * that is a win depends on which side you were, so the two columns have
+ * to be read together. The whole disjunction is parenthesized: AND binds
+ * tighter than OR, and an unscoped branch here would match other users'
+ * rows once combined with the ownership condition.
  */
 function outcomePredicate(
   outcome: NonNullable<GameFilters["outcome"]>,
   perspective: SQL,
 ): SQL {
-  if (outcome === "draw") return sql`${games.result} = '1/2-1/2'`;
+  if (outcome === "draw") return sql`(${games.result} = '1/2-1/2')`;
 
   const yourResult = outcome === "win" ? "1-0" : "0-1";
   const theirResult = outcome === "win" ? "0-1" : "1-0";
-  return sql`((${perspective}) = 'white' and ${games.result} = ${yourResult})
-    or ((${perspective}) = 'black' and ${games.result} = ${theirResult})`;
+  return sql`(((${perspective}) = 'white' and ${games.result} = ${yourResult})
+    or ((${perspective}) = 'black' and ${games.result} = ${theirResult}))`;
 }
 
-function gameFilterConditions(account: GameAccount, filters: GameFilters): SQL[] {
-  const perspective = perspectiveSql(account.username);
-  const conditions: SQL[] = [eq(games.accountId, account.id)];
+function gameFilterConditions(userId: string, filters: GameFilters): SQL[] {
+  const conditions: SQL[] = [eq(games.userId, userId)];
 
-  if (filters.color) conditions.push(sql`(${perspective}) = ${filters.color}`);
-  if (filters.outcome) conditions.push(outcomePredicate(filters.outcome, perspective));
+  if (filters.color) conditions.push(sql`(${perspectiveSql}) = ${filters.color}`);
+  if (filters.outcome) {
+    conditions.push(outcomePredicate(filters.outcome, perspectiveSql));
+  }
   if (filters.timeClass) conditions.push(timeClassPredicate(filters.timeClass));
 
   if (filters.verdict === "unjudged") {
@@ -105,7 +105,10 @@ function gameFilterConditions(account: GameAccount, filters: GameFilters): SQL[]
 }
 
 /**
- * One page of games, filtered, with everything the list renders. The
+ * One page of the user's unified library — synced accounts and manually
+ * imported PGNs together, filtered, with everything the list renders.
+ * The account join is provenance only: it feeds perspective derivation
+ * for games that have one and must not drop the ones that don't. The
  * DISTINCT ON picking a game's most actionable judgment lives in a
  * subquery, not the outer select — on top it would pin the sort and
  * block ordering by date. Verdict filtering is a separate EXISTS since
@@ -114,12 +117,11 @@ function gameFilterConditions(account: GameAccount, filters: GameFilters): SQL[]
  */
 export async function listGamesPage(
   db: Database,
-  account: GameAccount,
+  userId: string,
   filters: GameFilters = {},
   { page, pageSize }: GamePage = { page: 1, pageSize: 25 },
 ) {
-  const where = and(...gameFilterConditions(account, filters))!;
-  const perspective = perspectiveSql(account.username);
+  const where = and(...gameFilterConditions(userId, filters))!;
 
   const judgment = db
     .selectDistinctOn([deviations.gameId], {
@@ -145,7 +147,7 @@ export async function listGamesPage(
       blackRating: games.blackRating,
       result: games.result,
       playedAt: games.playedAt,
-      perspective,
+      perspective: perspectiveSql,
       source: games.source,
       externalUrl: games.externalUrl,
       timeControlInitialSeconds: games.timeControlInitialSeconds,
@@ -157,6 +159,9 @@ export async function listGamesPage(
       analyzed: isNotNull(gameAnalyses.id),
     })
     .from(games)
+    // Provenance, not ownership — perspective derivation input for the
+    // synced rows; a PGN row has none and must survive the read.
+    .leftJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
     .leftJoin(judgment, eq(judgment.gameId, games.id))
     .leftJoin(gameAnalyses, eq(gameAnalyses.gameId, games.id))
     .where(where)
@@ -164,6 +169,8 @@ export async function listGamesPage(
 
   // Newest first, id as the tiebreak: `played_at` is nullable and repeats
   // within a minute, and a partial order lets a row show up on two pages.
+  // The count shares the page's joins — the filters speak the same
+  // perspective rule, which references the provenance account.
   const [rows, [totals]] = await Promise.all([
     withPagination(
       page$,
@@ -171,7 +178,11 @@ export async function listGamesPage(
       page,
       pageSize,
     ),
-    db.select({ total: count() }).from(games).where(where),
+    db
+      .select({ total: count() })
+      .from(games)
+      .leftJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
+      .where(where),
   ]);
 
   return { rows, total: totals?.total ?? 0, page, pageSize } satisfies Paginated<
@@ -181,12 +192,13 @@ export async function listGamesPage(
 
 export type GameRow = Awaited<ReturnType<typeof listGamesPage>>["rows"][number];
 
-/** Games of the user's accounts not yet judged BY THIS repertoire —
- * judgments accumulate per (game, repertoire), so a new repertoire (e.g.
- * a fresh extraction) reaches games older repertoires already judged.
- * Carries player names + the account username so the caller can derive
- * perspective when the game doesn't store one (synced games don't — the
- * normalizer can't know who "you" are; the tracked account can). */
+/** The user's games not yet judged BY THIS repertoire — judgments
+ * accumulate per (game, repertoire), so a new repertoire (e.g. a fresh
+ * extraction) reaches games older repertoires already judged. Carries
+ * player names + the provenance account username so the caller can
+ * derive perspective when the game doesn't store one (synced games
+ * don't — the normalizer can't know who "you" are; the tracked account
+ * can; an imported PGN already resolved it at import). */
 export async function listUnjudgedGames(
   db: Database,
   userId: string,
@@ -202,10 +214,10 @@ export async function listUnjudgedGames(
       accountUsername: trackedAccounts.username,
     })
     .from(games)
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
+    .leftJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
     .where(
       and(
-        eq(trackedAccounts.userId, userId),
+        eq(games.userId, userId),
         notExists(
           db
             .select({ one: deviations.id })
@@ -237,6 +249,6 @@ export async function listGamesForExtraction(db: Database, userId: string) {
       openingUrl: games.openingUrl,
     })
     .from(games)
-    .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
-    .where(eq(trackedAccounts.userId, userId));
+    .leftJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
+    .where(eq(games.userId, userId));
 }

--- a/libs/infra/db/schema.ts
+++ b/libs/infra/db/schema.ts
@@ -279,9 +279,19 @@ export const games = pgTable(
   "games",
   {
     id: uuid("id").primaryKey().defaultRandom(),
+    /**
+     * The owner. Direct, not inferred through a tracked account: a PGN
+     * upload has no account to hang ownership from, and every read would
+     * otherwise need an inner join that silently drops it. `account_id`
+     * stays as provenance only — which connected handle produced the row.
+     */
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
     source: gameSourceEnum("source").notNull(),
     externalId: text("external_id"),
     externalUrl: text("external_url"),
+    /** Provider provenance — null for manually imported PGNs. */
     accountId: uuid("account_id").references(() => trackedAccounts.id, {
       onDelete: "set null",
     }),
@@ -308,19 +318,26 @@ export const games = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    // Both scoped to the tracked account: each account owns a complete,
-    // independent copy of whatever it imports, and dedup only ever
-    // happens within one account — never across two accounts tracking
-    // the same real provider handle.
+    // One platform game is one row per account: each account owns a
+    // complete, independent copy of whatever it imports, and external-id
+    // dedup never crosses two accounts — even two tracking the same real
+    // provider handle.
     uniqueIndex("games_account_source_external_id")
       .on(table.accountId, table.source, table.externalId)
       .where(sql`${table.externalId} is not null`),
-    unique("games_account_movetext")
-      .on(table.accountId, table.movetextHash)
+    // Movetext dedup is user-scoped. `nullsNotDistinct` makes a NULL
+    // account_id equal to itself within the composite: two pasted PGNs of
+    // one user with the same moves collapse to a no-op (the re-import is
+    // idempotent), while another user importing the very same file keeps
+    // their own row — ownership is per user, not global.
+    unique("games_user_account_movetext")
+      .on(table.userId, table.accountId, table.movetextHash)
       .nullsNotDistinct(),
+    // The unified library read: every game the user owns, newest first.
+    index("games_user_played_at").on(table.userId, table.playedAt.desc()),
     // Doubles as the account_id FK index — a composite index also serves
     // lookups/joins on just its leftmost column, so this covers both the
-    // game-list query and the account_id FK, no separate index needed.
+    // account-scoped game-list query and the account_id FK.
     index("games_account_played_at").on(table.accountId, table.playedAt.desc()),
   ],
 );

--- a/libs/infra/db/tests/adherence-flow.test.ts
+++ b/libs/infra/db/tests/adherence-flow.test.ts
@@ -27,11 +27,13 @@ import {
   users,
 } from "@velachess/db";
 
-import { createTestDb } from "./test-db.ts";
+import { createTestDb, createUserRow } from "./test-db.ts";
 
 const { db, close } = await createTestDb();
 
 afterAll(() => close());
+
+let ownerId: string;
 
 beforeEach(async () => {
   await db.delete(deviations);
@@ -39,6 +41,7 @@ beforeEach(async () => {
   await db.delete(repertoires);
   await db.delete(games);
   await db.delete(users);
+  ownerId = await createUserRow(db);
 });
 
 const ITALIAN = "1. e4 e5 2. Nf3 Nc6 3. Bc4 *";
@@ -60,6 +63,7 @@ function insertGame(
   return database
     .insert(games)
     .values({
+      userId: ownerId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",

--- a/libs/infra/db/tests/analysis-flow.test.ts
+++ b/libs/infra/db/tests/analysis-flow.test.ts
@@ -29,7 +29,7 @@ import {
   users,
 } from "@velachess/db";
 
-import { createTestDb } from "./test-db.ts";
+import { createTestDb, createUserRow } from "./test-db.ts";
 
 const require = createRequire(import.meta.url);
 const enginePath = require.resolve("stockfish/bin/stockfish-18-lite-single.js");
@@ -46,6 +46,8 @@ const { db, close } = await createTestDb();
 
 afterAll(() => close());
 
+let ownerId: string;
+
 beforeEach(async () => {
   await db.delete(gameAnalyses);
   await db.delete(deviations);
@@ -53,6 +55,7 @@ beforeEach(async () => {
   await db.delete(repertoires);
   await db.delete(games);
   await db.delete(users);
+  ownerId = await createUserRow(db);
 });
 
 function firstGame(pgn: string): Game<PgnNodeData> {
@@ -65,6 +68,7 @@ function insertGame(database: Database, rawPgn: string, movetextHash: string) {
   return database
     .insert(games)
     .values({
+      userId: ownerId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",

--- a/libs/infra/db/tests/analysis-progress.test.ts
+++ b/libs/infra/db/tests/analysis-progress.test.ts
@@ -23,22 +23,26 @@ import {
   users,
 } from "@velachess/db";
 
-import { createTestDb } from "./test-db.ts";
+import { createTestDb, createUserRow } from "./test-db.ts";
 
 const { db, close } = await createTestDb();
 
 afterAll(() => close());
 
+let userId: string;
+
 beforeEach(async () => {
   await db.delete(analysisProgress);
   await db.delete(games);
   await db.delete(users);
+  userId = await createUserRow(db);
 });
 
 function insertGame(database: Database) {
   return database
     .insert(games)
     .values({
+      userId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",

--- a/libs/infra/db/tests/drill-context.test.ts
+++ b/libs/infra/db/tests/drill-context.test.ts
@@ -41,6 +41,7 @@ async function aGame(): Promise<string> {
   const [game] = await db
     .insert(games)
     .values({
+      userId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",

--- a/libs/infra/db/tests/drill-flow.test.ts
+++ b/libs/infra/db/tests/drill-flow.test.ts
@@ -36,11 +36,13 @@ import {
   users,
 } from "@velachess/db";
 
-import { createTestDb } from "./test-db.ts";
+import { createTestDb, createUserRow } from "./test-db.ts";
 
 const { db, close } = await createTestDb();
 
 afterAll(() => close());
+
+let ownerId: string;
 
 beforeEach(async () => {
   await db.delete(drillResponses);
@@ -50,6 +52,7 @@ beforeEach(async () => {
   await db.delete(repertoires);
   await db.delete(games);
   await db.delete(users);
+  ownerId = await createUserRow(db);
 });
 
 const CHAPTER_PGN = "1. e4 e6 2. d4 d5 3. Nc3 *";
@@ -64,6 +67,7 @@ function insertGame(database: Database, movetextHash: string) {
   return database
     .insert(games)
     .values({
+      userId: ownerId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",

--- a/libs/infra/db/tests/drill-queue.test.ts
+++ b/libs/infra/db/tests/drill-queue.test.ts
@@ -57,6 +57,7 @@ async function aGame(): Promise<string> {
   const [game] = await db
     .insert(games)
     .values({
+      userId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",

--- a/libs/infra/db/tests/queries.test.ts
+++ b/libs/infra/db/tests/queries.test.ts
@@ -70,8 +70,14 @@ describe("libs/infra/db (games + tracked accounts)", () => {
 
   it("saveGames twice with the same Chess.com game inserts it once", async () => {
     const account = await upsertTrackedAccount(db, ownerId, "chess_com", "Test-Player");
-    const first = await saveGames(db, [chessComGame()], { accountId: account.id });
-    const second = await saveGames(db, [chessComGame()], { accountId: account.id });
+    const first = await saveGames(db, [chessComGame()], {
+      userId: ownerId,
+      accountId: account.id,
+    });
+    const second = await saveGames(db, [chessComGame()], {
+      userId: ownerId,
+      accountId: account.id,
+    });
 
     expect(first.inserted).toBe(1);
     expect(second.inserted).toBe(0);
@@ -86,8 +92,14 @@ describe("libs/infra/db (games + tracked accounts)", () => {
     const accountA = await upsertTrackedAccount(db, ownerId, "chess_com", "Test-Player");
     const accountB = await upsertTrackedAccount(db, other, "chess_com", "Test-Player");
 
-    const first = await saveGames(db, [chessComGame()], { accountId: accountA.id });
-    const second = await saveGames(db, [chessComGame()], { accountId: accountB.id });
+    const first = await saveGames(db, [chessComGame()], {
+      userId: ownerId,
+      accountId: accountA.id,
+    });
+    const second = await saveGames(db, [chessComGame()], {
+      userId: other,
+      accountId: accountB.id,
+    });
 
     expect(first.inserted).toBe(1);
     expect(second.inserted).toBe(1);
@@ -100,22 +112,40 @@ describe("libs/infra/db (games + tracked accounts)", () => {
     expect(rowsB).toHaveLength(1);
   });
 
-  it("the same pasted PGN twice with no account inserts it once — proves NULLS NOT DISTINCT is applied", async () => {
-    const first = await saveGames(db, [pastedGame()]);
-    const second = await saveGames(db, [pastedGame()]);
+  it("a pasted PGN re-imported by the same user inserts it once", async () => {
+    const first = await saveGames(db, [pastedGame()], { userId: ownerId });
+    const second = await saveGames(db, [pastedGame()], { userId: ownerId });
 
     expect(first.inserted).toBe(1);
     expect(second.inserted).toBe(0);
   });
 
+  it("two users importing the same pasted PGN each keep their own copy", async () => {
+    // Ownership is per user: movetext dedup must not leak one user's
+    // paste into another's library as an invisible skip.
+    const other = (await createUser(db)).id;
+    const mine = await saveGames(db, [pastedGame()], { userId: ownerId });
+    const theirs = await saveGames(db, [pastedGame()], { userId: other });
+
+    expect(mine.inserted).toBe(1);
+    expect(theirs.inserted).toBe(1);
+    expect(await listGames(db, { userId: ownerId })).toHaveLength(1);
+    expect(await listGames(db, { userId: other })).toHaveLength(1);
+  });
+
   it("a batch containing an intra-statement duplicate only inserts one row", async () => {
-    const result = await saveGames(db, [pastedGame(), pastedGame()]);
+    const result = await saveGames(db, [pastedGame(), pastedGame()], {
+      userId: ownerId,
+    });
     expect(result.inserted).toBe(1);
   });
 
   it("deleting a tracked account leaves its games with account_id set to null", async () => {
     const account = await upsertTrackedAccount(db, ownerId, "chess_com", "Test-Player");
-    await saveGames(db, [chessComGame()], { accountId: account.id });
+    await saveGames(db, [chessComGame()], {
+      userId: ownerId,
+      accountId: account.id,
+    });
 
     await db.delete(trackedAccounts).where(eq(trackedAccounts.id, account.id));
 
@@ -176,9 +206,9 @@ describe("libs/infra/db (games + tracked accounts)", () => {
           playedAt: new Date("2024-01-02T00:00:00Z"),
         }),
       ],
-      { accountId: account.id },
+      { userId: ownerId, accountId: account.id },
     );
-    await saveGames(db, [pastedGame()]); // unrelated, no account
+    await saveGames(db, [pastedGame()], { userId: ownerId }); // unrelated, no account
 
     const rows = await listGames(db, { accountId: account.id });
     expect(rows).toHaveLength(2);

--- a/libs/infra/db/tests/repertoire-flow.test.ts
+++ b/libs/infra/db/tests/repertoire-flow.test.ts
@@ -27,7 +27,7 @@ import {
   users,
 } from "@velachess/db";
 
-import { createTestDb } from "./test-db.ts";
+import { createTestDb, createUserRow } from "./test-db.ts";
 
 const CHAPTER_PGN = "1. e4 e6 2. d4 d5 3. Nc3 *";
 
@@ -35,6 +35,7 @@ function insertGame(db: Database, movetextHash: string) {
   return db
     .insert(games)
     .values({
+      userId: ownerId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",
@@ -58,6 +59,8 @@ const { db, close } = await createTestDb();
 
 afterAll(() => close());
 
+let ownerId: string;
+
 beforeEach(async () => {
   await db.delete(deviations);
   await db.delete(repertoireChapters);
@@ -65,6 +68,7 @@ beforeEach(async () => {
   await db.delete(games);
   await db.delete(trackedAccounts);
   await db.delete(users);
+  ownerId = await createUserRow(db);
 });
 
 describe("users", () => {

--- a/libs/infra/db/tests/scheduler-flow.test.ts
+++ b/libs/infra/db/tests/scheduler-flow.test.ts
@@ -34,11 +34,13 @@ import {
   users,
 } from "@velachess/db";
 
-import { createTestDb } from "./test-db.ts";
+import { createTestDb, createUserRow } from "./test-db.ts";
 
 const { db, close } = await createTestDb();
 
 afterAll(() => close());
+
+let ownerId: string;
 
 beforeEach(async () => {
   await db.delete(cards);
@@ -49,6 +51,7 @@ beforeEach(async () => {
   await db.delete(repertoires);
   await db.delete(games);
   await db.delete(users);
+  ownerId = await createUserRow(db);
 });
 
 const CHAPTER_PGN = "1. e4 e6 2. d4 d5 3. Nc3 *";
@@ -83,6 +86,7 @@ async function setupExercise(database: Database) {
   const [game] = await database
     .insert(games)
     .values({
+      userId: ownerId,
       source: "pgn",
       whiteName: "w",
       blackName: "b",

--- a/libs/infra/db/tests/status-flow.test.ts
+++ b/libs/infra/db/tests/status-flow.test.ts
@@ -77,7 +77,7 @@ beforeAll(async () => {
   const account = await upsertTrackedAccount(db, userId, "chess_com", "looper");
   accountId = account.id;
 
-  await saveGames(db, [syncedGame("1001")], { accountId });
+  await saveGames(db, [syncedGame("1001")], { userId, accountId });
   const [game] = await listGamesWithStatus(db, accountId);
   gameId = game!.id;
 

--- a/libs/infra/db/tests/test-db.ts
+++ b/libs/infra/db/tests/test-db.ts
@@ -6,6 +6,7 @@
  */
 
 import { PGlite } from "@electric-sql/pglite";
+import { randomUUID } from "node:crypto";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
 import { drizzle as drizzlePostgres } from "drizzle-orm/postgres-js";
@@ -14,6 +15,7 @@ import postgres from "postgres";
 
 import type { Database } from "../client.ts";
 import * as schema from "../schema.ts";
+import { users } from "../schema.ts";
 
 const migrationsFolder = new URL("../migrations", import.meta.url).pathname;
 
@@ -35,4 +37,19 @@ export async function createTestDb(): Promise<{
   await migratePglite(pgliteDb, { migrationsFolder });
   const db: Database = pgliteDb;
   return { db, close: () => pglite.close() };
+}
+
+/**
+ * Every owned row hangs from a user — games included, since ownership
+ * became direct. Tests that don't care whose user it is still need one.
+ */
+export async function createUserRow(db: Database): Promise<string> {
+  const [user] = await db
+    .insert(users)
+    .values({
+      displayName: "Test User",
+      email: `${randomUUID()}@test.local`,
+    })
+    .returning({ id: users.id });
+  return user!.id;
 }

--- a/libs/infra/platforms/providers/pgn.ts
+++ b/libs/infra/platforms/providers/pgn.ts
@@ -6,13 +6,27 @@
  */
 
 import { isSyncFailure, normalizeGame } from "../normalize.ts";
+import type { NormalizedGame, Perspective, SyncFailure, SyncResult } from "../schema.ts";
 import { splitPgnGames } from "../split.ts";
-import type { Perspective, SyncFailure, SyncResult } from "../schema.ts";
 
 export interface ImportPgnOptions {
-  /** Which side is "you", if the caller already knows. Never guessed here —
-   * absent means every game in this text carries `perspective: null`. */
-  perspective?: Perspective;
+  /**
+   * The player these games belong to, as their name appears in the PGN
+   * headers. Resolved per game against White/Black, so one file can mix
+   * colors; a game naming them on neither side stays `perspective: null`
+   * — present in the library, not attributable. Absent means every game
+   * carries `perspective: null`. Never guessed here.
+   */
+  playerName?: string | undefined;
+}
+
+/** Case-insensitive header match: PGN names are free text, not handles. */
+function sideOf(game: NormalizedGame, playerName: string): Perspective | null {
+  const name = playerName.trim().toLowerCase();
+  if (!name) return null;
+  if (game.white.name.trim().toLowerCase() === name) return "white";
+  if (game.black.name.trim().toLowerCase() === name) return "black";
+  return null;
 }
 
 export function importPgn(text: string, options: ImportPgnOptions = {}): SyncResult {
@@ -24,14 +38,17 @@ export function importPgn(text: string, options: ImportPgnOptions = {}): SyncRes
       origin: "pgn",
       externalId: null,
       externalUrl: null,
-      perspective: options.perspective ?? null,
     });
 
     if (isSyncFailure(result)) {
       failures.push({ ...result, ref: `game-${index}` });
       continue;
     }
-    games.push(result);
+    games.push(
+      options.playerName
+        ? { ...result, perspective: sideOf(result, options.playerName) }
+        : result,
+    );
   }
 
   return { games, failures, cursor: null, complete: failures.length === 0 };

--- a/libs/infra/platforms/tests/providers/pgn.test.ts
+++ b/libs/infra/platforms/tests/providers/pgn.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  FOOLS_MATE_PGN,
+  ILLEGAL_MOVE_PGN,
+  IMPORTED_PLAYER_NAME,
+  MIXED_COLOR_PGN,
+  MULTI_GAME_PGN,
+} from "@velachess/fixtures";
 import { importPgn } from "@velachess/platforms";
-import { FOOLS_MATE_PGN, MULTI_GAME_PGN, ILLEGAL_MOVE_PGN } from "@velachess/fixtures";
 
 describe("importPgn", () => {
   it("normalizes a single pasted game with no provenance and no perspective", () => {
@@ -19,9 +25,21 @@ describe("importPgn", () => {
     expect(result.games).toHaveLength(2);
   });
 
-  it("carries an explicit perspective onto every normalized game", () => {
-    const result = importPgn(MULTI_GAME_PGN, { perspective: "white" });
-    expect(result.games.every((g) => g.perspective === "white")).toBe(true);
+  it("resolves the named player's seat in each game of a mixed-color file", () => {
+    const result = importPgn(MIXED_COLOR_PGN, { playerName: IMPORTED_PLAYER_NAME });
+    expect(result.games.map((game) => game.perspective)).toEqual(["white", "black"]);
+  });
+
+  it("matches the player's name case-insensitively", () => {
+    const result = importPgn(MIXED_COLOR_PGN, {
+      playerName: IMPORTED_PLAYER_NAME.toLowerCase(),
+    });
+    expect(result.games.map((game) => game.perspective)).toEqual(["white", "black"]);
+  });
+
+  it("leaves games without the named player unattributed instead of guessing", () => {
+    const result = importPgn(MIXED_COLOR_PGN, { playerName: "Someone Else" });
+    expect(result.games.every((game) => game.perspective === null)).toBe(true);
   });
 
   it("normalizeGame still accepts a PGN with an illegal move — legality is not this package's job", () => {


### PR DESCRIPTION
## What

Adds manual PGN file import as a third source, next to the connected Chess.com/Lichess accounts. An explicit, repeatable upload with no account, no cursor, and no sync lifecycle. Games land in the same unified library and go through the existing Analysis → Repertoire → Deviations → Drill flow.

Closes #5

## How

### Direct ownership
- `games.user_id` NOT NULL → `users(id) ON DELETE CASCADE` (migration `0019`, backfills from `tracked_accounts` before setting NOT NULL)
- Every read that inferred ownership through joins on `tracked_accounts` now scopes directly on the column; `account_id` remains provenance only (null for PGN imports)
- Movetext dedup becomes user-scoped: `(user_id, account_id, movetext_hash) NULLS NOT DISTINCT` — re-uploading the same file is a counted no-op for its owner, while another user importing it keeps their own copy

### Backend
- New slice `libs/application/games/import-pgn/`: normalizes in-request, resolving the named player's seat **per game** against the White/Black headers (one file may mix colors), persists with conflict-ignore, and returns `{ imported, duplicates, rejected, judged, seeded }`
- After new games are saved it runs the same tail a sync runs: extract → judge → seed. Stockfish is never queued
- `POST /games/import` documented in the OpenAPI; `GET /games` is now the unified library — one filtered page of every game the caller owns, across all sources

### Frontend
- Separate **"Import PGN"** action in the Games header: dialog with player name (required), `.pgn` file or paste, and a toast receipt naming every pile
- `sources.ts` stays provider-only (no PGN among the connection tabs), per the issue guidance
- The list no longer gates on a remembered account: a manual import alone is a first-class way to have a library
- New copy extracted to the en / es / pt-BR catalogues

## Latent bug fixed along the way

The SQL predicate for the outcome filter had an unparenthesized disjunction: combined with ownership (`user_id = $1 AND win OR loss`), AND precedence let the *loss* branch match other users' rows once perspective started reading the joined account instead of a bound username. Now parenthesized and pinned by tests.

## Acceptance criteria

- [x] Chess.com, Lichess and PGN games in one Games library
- [x] PGN import creates no connected account
- [x] Repeated PGN imports without duplicate rows (`duplicates` counted, always 200)
- [x] Duplicate-only imports succeed
- [x] Mixed-color PGNs resolve the user's perspective per game
- [x] Two users can independently import the same PGN
- [x] Account sync affects only Chess.com/Lichess
- [x] Import never queues engine analysis
- [x] Imported games support the existing Analysis → Repertoire → Deviations → Drill flow (verified end-to-end over HTTP: repertoire + chapter → import → judged → `GET /deviations`)
- [x] Backend coverage through HTTP with real migrations (`apps/server/tests/pgn-import.test.ts`)
- [x] Frontend coverage asserts visible behavior (dialog, header actions, account-free library)
- [x] New copy uses Lingui, all three catalogues extracted

## Verification

`pnpm check` · `pnpm fmt:check` · `pnpm test` (871 tests, all projects) · `pnpm e2e` · `pnpm build` — all green.

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/27bafb86-9422-4f90-9a57-40c884116004" />

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/da43c5bb-e76c-4ffb-b93c-180d082956cd" />
