### PR TITLE
fix: count only repertoire deviations in overview

### DIFF
--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -453,14 +453,44 @@ describe("api routes", () => {
   });
 
   it("the dashboard reflects the loop so far", async () => {
-    const overview = (await (await owner.request("/overview")).json()) as Record<
+    const dashboard = (await harness.signUp("overview@api.test")).app;
+    const imported = await dashboard.request(
+      "/accounts",
+      json({ platform: "chess_com", username: "Looper" }),
+    );
+    expect(imported.status).toBe(201);
+    const account = (await imported.json()) as { id: string };
+    const created = await dashboard.request(
+      "/repertoires",
+      json({ name: "White e4", color: "white" }),
+    );
+    expect(created.status).toBe(201);
+    const repertoire = (await created.json()) as { id: string };
+    const chapter = await dashboard.request(
+      `/repertoires/${repertoire.id}/chapters`,
+      json({ name: "French", pgn: LOOPER_REPERTOIRE_PGN }),
+    );
+    expect(chapter.status).toBe(201);
+    expect((await dashboard.request("/games/judge", { method: "POST" })).status).toBe(
+      200,
+    );
+
+    const games = (await (
+      await dashboard.request(`/accounts/${account.id}/games`)
+    ).json()) as { judgmentType: string }[];
+    expect(games.map((game) => game.judgmentType).toSorted()).toEqual([
+      "completed",
+      "deviation",
+    ]);
+
+    const overview = (await (await dashboard.request("/overview")).json()) as Record<
       string,
       number
     >;
     // Three exercises already: judging seeds the repertoire deviation
     // without waiting for the engine, and the chapter's own decision
     // positions seed as repertoire-line the moment the chapter lands.
-    expect(overview).toEqual({ games: 2, deviations: 2, exercises: 3, dueCards: 0 });
+    expect(overview).toEqual({ games: 2, deviations: 1, exercises: 3, dueCards: 0 });
   });
 
   it("GET /games/:id returns the full game with rawPgn for board replay", async () => {

--- a/apps/web/src/dashboard/dashboard.tsx
+++ b/apps/web/src/dashboard/dashboard.tsx
@@ -21,7 +21,7 @@ const DASHBOARD_COPY = {
   unavailable: msg`—`,
   counters: {
     games: { label: msg`Games`, hint: msg`imported from your accounts` },
-    mistakes: { label: msg`Mistakes`, hint: msg`found in your repertoire` },
+    deviations: { label: msg`Deviations`, hint: msg`found in your repertoire` },
     exercises: { label: msg`Exercises`, hint: msg`made from your worst ones` },
     dueCards: { label: msg`Due now`, hint: msg`waiting for you today` },
   },
@@ -29,7 +29,7 @@ const DASHBOARD_COPY = {
 
 const COUNTERS = [
   { key: "games", ...DASHBOARD_COPY.counters.games },
-  { key: "deviations", ...DASHBOARD_COPY.counters.mistakes },
+  { key: "deviations", ...DASHBOARD_COPY.counters.deviations },
   { key: "exercises", ...DASHBOARD_COPY.counters.exercises },
   { key: "dueCards", ...DASHBOARD_COPY.counters.dueCards },
 ] satisfies { key: keyof Overview; label: MessageDescriptor; hint: MessageDescriptor }[];

--- a/apps/web/src/dashboard/tests/dashboard.test.tsx
+++ b/apps/web/src/dashboard/tests/dashboard.test.tsx
@@ -21,6 +21,7 @@ describe("dashboard", () => {
     await renderApp({ path: "/" });
 
     expect(await screen.findByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Deviations")).toBeInTheDocument();
     expect(screen.getByText("14")).toBeInTheDocument();
     expect(screen.getAllByText("0")).toHaveLength(3);
   });

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -228,11 +228,11 @@ msgstr "Blunders per game"
 msgid "Board"
 msgstr "Board"
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr "Board interaction preferences."
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr "Board preferences like coordinates, move animation, and sound will land here once they exist."
 
@@ -384,6 +384,10 @@ msgstr "Dashboard"
 msgid "Date"
 msgstr "Date"
 
+#: src/dashboard/dashboard.tsx:24
+msgid "Deviations"
+msgstr "Deviations"
+
 #: src/games/list/columns.tsx:20
 #: src/games/list/filters.ts:41
 #: src/games/open-game/game-result.tsx:11
@@ -507,7 +511,7 @@ msgid "Game phases"
 msgstr "Game phases"
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
@@ -711,10 +715,6 @@ msgstr "middlegame"
 msgid "Mistake"
 msgstr "Mistake"
 
-#: src/dashboard/dashboard.tsx:24
-msgid "Mistakes"
-msgstr "Mistakes"
-
 #: src/insights/finding-views.tsx:368
 msgid "Mistakes keep landing in your {phase}"
 msgstr "Mistakes keep landing in your {phase}"
@@ -818,7 +818,7 @@ msgstr "Nothing due today"
 msgid "Nothing in the position was worth more."
 msgstr "Nothing in the position was worth more."
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr "Nothing to configure yet"
 

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -228,11 +228,11 @@ msgstr ""
 msgid "Board"
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr ""
 
@@ -384,6 +384,10 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
+#: src/dashboard/dashboard.tsx:24
+msgid "Deviations"
+msgstr ""
+
 #: src/games/list/columns.tsx:20
 #: src/games/list/filters.ts:41
 #: src/games/open-game/game-result.tsx:11
@@ -507,7 +511,7 @@ msgid "Game phases"
 msgstr ""
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
@@ -711,10 +715,6 @@ msgstr ""
 msgid "Mistake"
 msgstr ""
 
-#: src/dashboard/dashboard.tsx:24
-msgid "Mistakes"
-msgstr ""
-
 #: src/insights/finding-views.tsx:368
 msgid "Mistakes keep landing in your {phase}"
 msgstr ""
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Nothing in the position was worth more."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr ""
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -228,11 +228,11 @@ msgstr ""
 msgid "Board"
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr ""
 
@@ -384,6 +384,10 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
+#: src/dashboard/dashboard.tsx:24
+msgid "Deviations"
+msgstr ""
+
 #: src/games/list/columns.tsx:20
 #: src/games/list/filters.ts:41
 #: src/games/open-game/game-result.tsx:11
@@ -507,7 +511,7 @@ msgid "Game phases"
 msgstr ""
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
@@ -711,10 +715,6 @@ msgstr ""
 msgid "Mistake"
 msgstr ""
 
-#: src/dashboard/dashboard.tsx:24
-msgid "Mistakes"
-msgstr ""
-
 #: src/insights/finding-views.tsx:368
 msgid "Mistakes keep landing in your {phase}"
 msgstr ""
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Nothing in the position was worth more."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr ""
 

--- a/docs/explanation/apps/web.md
+++ b/docs/explanation/apps/web.md
@@ -44,14 +44,15 @@ shell decides where that content goes.
 
 Data keeps the domain's name; screens are named after the user's job.
 
-| The API says   | The person sees | Why                                                                                 |
-| -------------- | --------------- | ----------------------------------------------------------------------------------- |
-| `deviation`    | Mistakes        | Nobody opens an app to see deviations. `deviation` is _how_ we detect it.           |
-| `review` (SRS) | Drill           | In chess products "Game Review" means analyzing a game — the collision is real.     |
-| `repertoire`   | Repertoire      | Same word on both sides, and that's fine: it's a word players use, not a mechanism. |
+| The API says   | The person sees             | Why                                                                                        |
+| -------------- | --------------------------- | ------------------------------------------------------------------------------------------ |
+| `deviation`    | Deviations on the dashboard | The overview names this exact repertoire count; task-focused flows can still say Mistakes. |
+| `review` (SRS) | Drill                       | In chess products "Game Review" means analyzing a game — the collision is real.            |
+| `repertoire`   | Repertoire                  | Same word on both sides, and that's fine: it's a word players use, not a mechanism.        |
 
 The rule is not "always differ" — it is "don't ship the mechanism's word
-to the user". The mapping happens once, at the edge, inside the slice.
+to the user unless the screen names that exact metric". The mapping happens
+once, at the edge, inside the slice.
 
 ## State: four owners, no overlap
 

--- a/libs/application/overview/get-overview/get-overview.ts
+++ b/libs/application/overview/get-overview/get-overview.ts
@@ -22,7 +22,7 @@ export async function getOverview(db: Database, userId: string, now: Date = new 
     .from(deviations)
     .innerJoin(games, eq(deviations.gameId, games.id))
     .innerJoin(trackedAccounts, eq(games.accountId, trackedAccounts.id))
-    .where(eq(trackedAccounts.userId, userId));
+    .where(and(eq(trackedAccounts.userId, userId), eq(deviations.type, "deviation")));
   const [exercisesRow] = await db
     .select({ n: count() })
     .from(exercises)


### PR DESCRIPTION
## Summary

- count only repertoire judgments with `type = "deviation"` in the dashboard overview
- rename the dashboard counter from "Mistakes" to "Deviations"
- keep the `/overview` response shape unchanged
- update Lingui catalogs and frontend vocabulary documentation

Fixes #10

## Verification

- `pnpm check`
- `pnpm fmt:check`
- server dashboard integration test: 1 passed
- web dashboard test suite: 4 passed
- `pnpm test` reached 6 `@velachess/engine` child-process/Stockfish failures in this environment; no engine files changed

## Evidence

Before: two judged games (one `deviation`, one `completed`) returned `deviations: 2`.

After: the same scenario returns `deviations: 1`.

## Checklist

- [x] Tests added or updated
- [x] Relevant evidence included
- [x] Documentation updated
- [x] No migration required