### PR TITLE
feat(web): improve evaluation graph with move categories and replay sync

### DIFF
--- a/apps/web/src/games/analysis-read.ts
+++ b/apps/web/src/games/analysis-read.ts
@@ -1,4 +1,6 @@
 import { scoreToWinChance } from "@velachess/analysis/winchance";
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import type { MoveSquares } from "@velachess/chess";
 import { makeSan, parseUci, positionFromFen, squaresOfSan } from "@velachess/chess";
 import type { BadgeTone } from "@velachess/ui/chess/board-theme";
@@ -149,6 +151,15 @@ export function badgeForCategory(
   if (!tone) return null;
   return { tone, label: glyphOf(category) ?? BEST_MOVE_GLYPH };
 }
+
+/** Translated category names for UI display. */
+export const CATEGORY_LABELS: Record<MoveCategory, MessageDescriptor> = {
+  best: msg`Best`,
+  good: msg`Good`,
+  inaccuracy: msg`Inaccuracy`,
+  mistake: msg`Mistake`,
+  blunder: msg`Blunder`,
+};
 
 export interface EvalPoint {
   ply: number;

--- a/apps/web/src/games/analysis-read.ts
+++ b/apps/web/src/games/analysis-read.ts
@@ -155,6 +155,10 @@ export interface EvalPoint {
   /** White's winning chances, 0–1. The graph's only vertical input. */
   winChance: number;
   category: MoveCategory;
+  /** The played move in SAN notation. */
+  san: string;
+  /** The evaluation after the move, from White's perspective. */
+  evalAfter: GradedPly["evalAfter"];
 }
 
 /** Delegates cp→win-chance to `@velachess/analysis`: an earlier local copy disagreed on mate handling. */
@@ -163,6 +167,8 @@ export function evalCurve(moves: GradedPly[]): EvalPoint[] {
     ply: move.ply,
     winChance: whiteShareOf(move.evalAfter),
     category: move.category,
+    san: move.san,
+    evalAfter: move.evalAfter,
   }));
 }
 

--- a/apps/web/src/games/open-game/analysis-panel.tsx
+++ b/apps/web/src/games/open-game/analysis-panel.tsx
@@ -73,7 +73,12 @@ export function AnalysisPanel({
   return (
     <BoardPanel label={i18n._(PANEL_COPY.region)}>
       <div className="shrink-0 border-b p-3">
-        <EvalGraph points={evalCurve(graded)} totalPlies={replay.totalPlies} />
+        <EvalGraph
+          points={evalCurve(graded)}
+          totalPlies={replay.totalPlies}
+          selectedPly={replay.ply}
+          onSelectPly={replay.goTo}
+        />
       </div>
 
       <AnalysisStatus

--- a/apps/web/src/games/view-analysis/eval-graph.tsx
+++ b/apps/web/src/games/view-analysis/eval-graph.tsx
@@ -6,7 +6,7 @@ import type { EvaluationPoint } from "@velachess/ui/charts/evaluation-chart";
 import { Skeleton } from "@velachess/ui/components/skeleton";
 
 import type { EvalPoint } from "../analysis-read.ts";
-import { formatScore } from "../analysis-read.ts";
+import { badgeForCategory, CATEGORY_LABELS, formatScore } from "../analysis-read.ts";
 
 const GRAPH_COPY = {
   title: msg`Evaluation over the game`,
@@ -43,7 +43,7 @@ export function EvalGraph({
     );
   }
 
-  // Build evaluation points with category colors and move info.
+  // Build evaluation points with tone colors and translated labels.
   const evaluationPoints: EvaluationPoint[] = Array.from(
     { length: Math.max(totalPlies, points.length) },
     (_, index) => {
@@ -55,12 +55,14 @@ export function EvalGraph({
         };
       }
 
+      const badge = badgeForCategory(point.category);
       const san = point.san ?? "";
 
       return {
         ply: point.ply,
         value: point.winChance,
-        category: point.category,
+        tone: badge?.tone,
+        label: badge ? i18n._(CATEGORY_LABELS[point.category]) : undefined,
         san,
         score: formatScore(point.evalAfter),
       };

--- a/apps/web/src/games/view-analysis/eval-graph.tsx
+++ b/apps/web/src/games/view-analysis/eval-graph.tsx
@@ -2,9 +2,11 @@ import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 
 import { EvaluationChart } from "@velachess/ui/charts/evaluation-chart";
+import type { EvaluationPoint } from "@velachess/ui/charts/evaluation-chart";
 import { Skeleton } from "@velachess/ui/components/skeleton";
 
 import type { EvalPoint } from "../analysis-read.ts";
+import { formatScore, moveNumberOf, sideOfPly } from "../analysis-read.ts";
 
 const GRAPH_COPY = {
   title: msg`Evaluation over the game`,
@@ -16,10 +18,19 @@ export interface EvalGraphProps {
   /** The axis, which is not the data: pinning it stops the curve
    * rescaling on every chunk while the analysis streams in. */
   totalPlies: number;
+  /** The ply currently selected in the replay. */
+  selectedPly?: number;
+  /** Called when a dot on the graph is clicked. */
+  onSelectPly?: (ply: number) => void;
 }
 
 /** Winning chances, not centipawns: cp is unbounded and one mate score flattens every other move. `domain` is fixed to avoid the same distortion. */
-export function EvalGraph({ points, totalPlies }: EvalGraphProps) {
+export function EvalGraph({
+  points,
+  totalPlies,
+  selectedPly,
+  onSelectPly,
+}: EvalGraphProps) {
   const { i18n } = useLingui();
 
   if (points.length === 0) {
@@ -32,16 +43,41 @@ export function EvalGraph({ points, totalPlies }: EvalGraphProps) {
     );
   }
 
-  // Padded to the full game so a half-streamed curve holds its final
-  // width instead of stretching and snapping back.
-  const series = Array.from(
+  // Build evaluation points with category colors and move info.
+  const evaluationPoints: EvaluationPoint[] = Array.from(
     { length: Math.max(totalPlies, points.length) },
-    (_, index) => points[index]?.winChance ?? points.at(-1)?.winChance ?? 0.5,
+    (_, index) => {
+      const point = points[index];
+      if (!point) {
+        return {
+          ply: index + 1,
+          value: points.at(-1)?.winChance ?? 0.5,
+        };
+      }
+
+      const side = sideOfPly(point.ply);
+      const moveSuffix = side === "white" ? "." : "…";
+      const san = `${moveNumberOf(point.ply)}${moveSuffix} ${point.san ?? ""}`.trim();
+
+      return {
+        ply: point.ply,
+        value: point.winChance,
+        category: point.category,
+        san,
+        score: formatScore(point.evalAfter),
+      };
+    },
   );
 
   return (
     <div className="h-20 overflow-hidden rounded-lg border bg-muted/30">
-      <EvaluationChart data={series} domain={[0, 1]} title={i18n._(GRAPH_COPY.title)} />
+      <EvaluationChart
+        data={evaluationPoints}
+        domain={[0, 1]}
+        title={i18n._(GRAPH_COPY.title)}
+        selectedPly={selectedPly}
+        onSelectPly={onSelectPly}
+      />
     </div>
   );
 }

--- a/apps/web/src/games/view-analysis/eval-graph.tsx
+++ b/apps/web/src/games/view-analysis/eval-graph.tsx
@@ -6,7 +6,7 @@ import type { EvaluationPoint } from "@velachess/ui/charts/evaluation-chart";
 import { Skeleton } from "@velachess/ui/components/skeleton";
 
 import type { EvalPoint } from "../analysis-read.ts";
-import { formatScore, moveNumberOf, sideOfPly } from "../analysis-read.ts";
+import { formatScore } from "../analysis-read.ts";
 
 const GRAPH_COPY = {
   title: msg`Evaluation over the game`,
@@ -55,9 +55,7 @@ export function EvalGraph({
         };
       }
 
-      const side = sideOfPly(point.ply);
-      const moveSuffix = side === "white" ? "." : "…";
-      const san = `${moveNumberOf(point.ply)}${moveSuffix} ${point.san ?? ""}`.trim();
+      const san = point.san ?? "";
 
       return {
         ply: point.ply,

--- a/apps/web/src/games/view-analysis/game-report.tsx
+++ b/apps/web/src/games/view-analysis/game-report.tsx
@@ -1,4 +1,3 @@
-import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 
@@ -6,20 +5,16 @@ import { Item, ItemContent, ItemMedia, ItemTitle } from "@velachess/ui/component
 import { BookOpen } from "@velachess/ui/icons";
 import { cn } from "@velachess/ui/lib/utils";
 
-import { categoriesInOrder, type SideBreakdown } from "../analysis-read.ts";
+import {
+  categoriesInOrder,
+  CATEGORY_LABELS,
+  type SideBreakdown,
+} from "../analysis-read.ts";
 import type { MoveCategory } from "../analysis-contract.ts";
 
 const REPORT_COPY = {
   unknownOpening: msg`Opening not recognised`,
 } as const;
-
-const CATEGORY_LABELS: Record<MoveCategory, MessageDescriptor> = {
-  best: msg`Best`,
-  good: msg`Good`,
-  inaccuracy: msg`Inaccuracy`,
-  mistake: msg`Mistake`,
-  blunder: msg`Blunder`,
-};
 
 /** The theme's severity tokens, mirroring `engine_category` in the database. */
 const CATEGORY_TONE: Record<MoveCategory, string> = {

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -182,7 +182,7 @@ msgstr "Back to the start"
 msgid "Backend unavailable · Retrying automatically"
 msgstr "Backend unavailable · Retrying automatically"
 
-#: src/games/view-analysis/game-report.tsx:17
+#: src/games/analysis-read.ts:157
 msgid "Best"
 msgstr "Best"
 
@@ -211,7 +211,7 @@ msgstr "Black to move"
 msgid "Blitz"
 msgstr "Blitz"
 
-#: src/games/view-analysis/game-report.tsx:21
+#: src/games/analysis-read.ts:161
 msgid "Blunder"
 msgstr "Blunder"
 
@@ -228,11 +228,11 @@ msgstr "Blunders per game"
 msgid "Board"
 msgstr "Board"
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr "Board interaction preferences."
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr "Board preferences like coordinates, move animation, and sound will land here once they exist."
 
@@ -453,7 +453,7 @@ msgstr "Enter your username"
 msgid "Evaluation"
 msgstr "Evaluation"
 
-#: src/games/view-analysis/eval-graph.tsx:10
+#: src/games/view-analysis/eval-graph.tsx:12
 msgid "Evaluation over the game"
 msgstr "Evaluation over the game"
 
@@ -507,7 +507,7 @@ msgid "Game phases"
 msgstr "Game phases"
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
@@ -524,7 +524,7 @@ msgstr "Games"
 msgid "Games pages"
 msgstr "Games pages"
 
-#: src/games/view-analysis/game-report.tsx:18
+#: src/games/analysis-read.ts:158
 msgid "Good"
 msgstr "Good"
 
@@ -572,7 +572,7 @@ msgstr "imported from your accounts"
 msgid "In the game, you played"
 msgstr "In the game, you played"
 
-#: src/games/view-analysis/game-report.tsx:19
+#: src/games/analysis-read.ts:159
 msgid "Inaccuracy"
 msgstr "Inaccuracy"
 
@@ -707,7 +707,7 @@ msgstr "Manage your account and application preferences."
 msgid "middlegame"
 msgstr "middlegame"
 
-#: src/games/view-analysis/game-report.tsx:20
+#: src/games/analysis-read.ts:160
 msgid "Mistake"
 msgstr "Mistake"
 
@@ -818,7 +818,7 @@ msgstr "Nothing due today"
 msgid "Nothing in the position was worth more."
 msgstr "Nothing in the position was worth more."
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr "Nothing to configure yet"
 
@@ -1152,7 +1152,7 @@ msgstr "That doesn't look like an email address."
 msgid "That username is too long"
 msgstr "That username is too long"
 
-#: src/games/view-analysis/eval-graph.tsx:11
+#: src/games/view-analysis/eval-graph.tsx:13
 msgid "The curve appears as the analysis lands."
 msgstr "The curve appears as the analysis lands."
 

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Backend unavailable · Retrying automatically"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:17
+#: src/games/analysis-read.ts:157
 msgid "Best"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Blitz"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:21
+#: src/games/analysis-read.ts:161
 msgid "Blunder"
 msgstr ""
 
@@ -228,11 +228,11 @@ msgstr ""
 msgid "Board"
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr ""
 
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Evaluation"
 msgstr ""
 
-#: src/games/view-analysis/eval-graph.tsx:10
+#: src/games/view-analysis/eval-graph.tsx:12
 msgid "Evaluation over the game"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgid "Game phases"
 msgstr ""
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Games pages"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:18
+#: src/games/analysis-read.ts:158
 msgid "Good"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgstr ""
 msgid "In the game, you played"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:19
+#: src/games/analysis-read.ts:159
 msgid "Inaccuracy"
 msgstr ""
 
@@ -707,7 +707,7 @@ msgstr ""
 msgid "middlegame"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:20
+#: src/games/analysis-read.ts:160
 msgid "Mistake"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Nothing in the position was worth more."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "That username is too long"
 msgstr ""
 
-#: src/games/view-analysis/eval-graph.tsx:11
+#: src/games/view-analysis/eval-graph.tsx:13
 msgid "The curve appears as the analysis lands."
 msgstr ""
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Backend unavailable · Retrying automatically"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:17
+#: src/games/analysis-read.ts:157
 msgid "Best"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Blitz"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:21
+#: src/games/analysis-read.ts:161
 msgid "Blunder"
 msgstr ""
 
@@ -228,11 +228,11 @@ msgstr ""
 msgid "Board"
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:8
+#: src/settings/gameplay/gameplay-screen.tsx:13
 msgid "Board interaction preferences."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:10
+#: src/settings/gameplay/gameplay-screen.tsx:15
 msgid "Board preferences like coordinates, move animation, and sound will land here once they exist."
 msgstr ""
 
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Evaluation"
 msgstr ""
 
-#: src/games/view-analysis/eval-graph.tsx:10
+#: src/games/view-analysis/eval-graph.tsx:12
 msgid "Evaluation over the game"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgid "Game phases"
 msgstr ""
 
 #: src/routes/_app/settings/gameplay.tsx:7
-#: src/settings/gameplay/gameplay-screen.tsx:7
+#: src/settings/gameplay/gameplay-screen.tsx:12
 #: src/settings/layout/navigation.ts:33
 #: src/test/routes.tsx:208
 msgid "Gameplay"
@@ -524,7 +524,7 @@ msgstr ""
 msgid "Games pages"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:18
+#: src/games/analysis-read.ts:158
 msgid "Good"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgstr ""
 msgid "In the game, you played"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:19
+#: src/games/analysis-read.ts:159
 msgid "Inaccuracy"
 msgstr ""
 
@@ -707,7 +707,7 @@ msgstr ""
 msgid "middlegame"
 msgstr ""
 
-#: src/games/view-analysis/game-report.tsx:20
+#: src/games/analysis-read.ts:160
 msgid "Mistake"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Nothing in the position was worth more."
 msgstr ""
 
-#: src/settings/gameplay/gameplay-screen.tsx:9
+#: src/settings/gameplay/gameplay-screen.tsx:14
 msgid "Nothing to configure yet"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "That username is too long"
 msgstr ""
 
-#: src/games/view-analysis/eval-graph.tsx:11
+#: src/games/view-analysis/eval-graph.tsx:13
 msgid "The curve appears as the analysis lands."
 msgstr ""
 

--- a/libs/ui/src/charts/evaluation-chart.tsx
+++ b/libs/ui/src/charts/evaluation-chart.tsx
@@ -1,13 +1,113 @@
-import { Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
+import { useCallback, useMemo } from "react";
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import { cn } from "../lib/utils.ts";
 
+export type MoveCategory = "best" | "good" | "inaccuracy" | "mistake" | "blunder";
+
+export interface EvaluationPoint {
+  ply: number;
+  value: number;
+  category?: MoveCategory;
+  san?: string;
+  score?: string;
+}
+
 export interface EvaluationChartProps {
-  data: number[];
+  data: EvaluationPoint[];
   domain?: [number, number];
   color?: string;
   title: string;
   className?: string;
+  selectedPly?: number | undefined;
+  onSelectPly?: ((ply: number) => void) | undefined;
+}
+
+const CATEGORY_COLORS: Record<MoveCategory, string> = {
+  best: "var(--move-ok)",
+  good: "var(--move-ok)",
+  inaccuracy: "var(--move-inaccuracy)",
+  mistake: "var(--move-mistake)",
+  blunder: "var(--move-blunder)",
+};
+
+function getPointColor(
+  category?: MoveCategory,
+  defaultColor: string = "var(--primary)",
+): string {
+  return category ? CATEGORY_COLORS[category] : defaultColor;
+}
+
+function CustomDot({
+  cx,
+  cy,
+  payload,
+  selectedPly,
+  defaultColor,
+  onSelectPly,
+}: {
+  cx?: number | undefined;
+  cy?: number | undefined;
+  payload: EvaluationPoint;
+  selectedPly?: number | undefined;
+  defaultColor: string;
+  onSelectPly?: ((ply: number) => void) | undefined;
+}) {
+  if (cx === undefined || cy === undefined) return null;
+
+  const isSelected = selectedPly === payload.ply;
+  const color = getPointColor(payload.category, defaultColor);
+  const radius = isSelected ? 4 : payload.category ? 3 : 2;
+  const strokeWidth = isSelected ? 2 : 0;
+
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={radius}
+      fill={color}
+      stroke="var(--background)"
+      strokeWidth={strokeWidth}
+      className={cn("transition-all duration-150", onSelectPly && "cursor-pointer")}
+      onClick={() => onSelectPly?.(payload.ply)}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelectPly?.(payload.ply);
+        }
+      }}
+    />
+  );
+}
+
+function CustomTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: EvaluationPoint }>;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0]?.payload;
+  if (!point) return null;
+
+  const color = getPointColor(point.category);
+
+  return (
+    <div className="rounded border bg-background p-2 text-sm shadow-md">
+      <div className="font-medium" style={{ color }}>
+        {point.san ?? `Ply ${point.ply}`}
+      </div>
+      {point.category && (
+        <div className="capitalize text-muted-foreground">{point.category}</div>
+      )}
+      {point.score && (
+        <div className="font-mono text-xs text-muted-foreground">{point.score}</div>
+      )}
+    </div>
+  );
 }
 
 export function EvaluationChart({
@@ -16,8 +116,31 @@ export function EvaluationChart({
   color = "var(--primary)",
   title,
   className,
+  selectedPly,
+  onSelectPly,
 }: EvaluationChartProps) {
-  const chartData = data.map((value, index) => ({ ply: index + 1, value }));
+  const chartData = useMemo(() => data, [data]);
+
+  const renderDot = useCallback(
+    (props: Record<string, unknown>) => {
+      const { cx, cy, payload } = props as {
+        cx?: number;
+        cy?: number;
+        payload: EvaluationPoint;
+      };
+      return (
+        <CustomDot
+          cx={cx}
+          cy={cy}
+          payload={payload}
+          selectedPly={selectedPly}
+          defaultColor={color}
+          onSelectPly={onSelectPly}
+        />
+      );
+    },
+    [selectedPly, color, onSelectPly],
+  );
 
   return (
     <div role="img" aria-label={title} className={cn("h-full w-full", className)}>
@@ -29,13 +152,14 @@ export function EvaluationChart({
         <LineChart data={chartData} margin={{ top: 6, right: 6, bottom: 6, left: 6 }}>
           <XAxis dataKey="ply" hide />
           <YAxis domain={domain ?? ["auto", "auto"]} hide />
+          <Tooltip content={<CustomTooltip />} />
           <Line
             type="linear"
             dataKey="value"
             stroke={color}
             strokeWidth={2}
-            dot={{ r: 2, fill: color, stroke: color }}
-            activeDot={{ r: 3, fill: color, stroke: color }}
+            dot={renderDot}
+            activeDot={{ r: 4, fill: color, stroke: "var(--background)", strokeWidth: 2 }}
             isAnimationActive={false}
           />
         </LineChart>

--- a/libs/ui/src/charts/evaluation-chart.tsx
+++ b/libs/ui/src/charts/evaluation-chart.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+// react-doctor-disable-next-line react-doctor/prefer-dynamic-import
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import { cn } from "../lib/utils.ts";

--- a/libs/ui/src/charts/evaluation-chart.tsx
+++ b/libs/ui/src/charts/evaluation-chart.tsx
@@ -2,16 +2,17 @@ import { useCallback, useMemo } from "react";
 // react-doctor-disable-next-line react-doctor/prefer-dynamic-import
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
+import type { BadgeTone } from "../chess/board-theme.ts";
+import { BADGE_TONE_COLOR } from "../chess/board-theme.ts";
 import { cn } from "../lib/utils.ts";
-
-export type MoveCategory = "best" | "good" | "inaccuracy" | "mistake" | "blunder";
 
 export interface EvaluationPoint {
   ply: number;
   value: number;
-  category?: MoveCategory;
-  san?: string;
-  score?: string;
+  tone?: BadgeTone | undefined;
+  label?: string | undefined;
+  san?: string | undefined;
+  score?: string | undefined;
 }
 
 export interface EvaluationChartProps {
@@ -24,19 +25,11 @@ export interface EvaluationChartProps {
   onSelectPly?: ((ply: number) => void) | undefined;
 }
 
-const CATEGORY_COLORS: Record<MoveCategory, string> = {
-  best: "var(--move-ok)",
-  good: "var(--move-ok)",
-  inaccuracy: "var(--move-inaccuracy)",
-  mistake: "var(--move-mistake)",
-  blunder: "var(--move-blunder)",
-};
-
 function getPointColor(
-  category?: MoveCategory,
+  tone?: BadgeTone,
   defaultColor: string = "var(--primary)",
 ): string {
-  return category ? CATEGORY_COLORS[category] : defaultColor;
+  return tone ? BADGE_TONE_COLOR[tone] : defaultColor;
 }
 
 function CustomDot({
@@ -57,8 +50,8 @@ function CustomDot({
   if (cx === undefined || cy === undefined) return null;
 
   const isSelected = selectedPly === payload.ply;
-  const color = getPointColor(payload.category, defaultColor);
-  const radius = isSelected ? 4 : payload.category ? 3 : 2;
+  const color = getPointColor(payload.tone, defaultColor);
+  const radius = isSelected ? 4 : payload.tone ? 3 : 2;
   const strokeWidth = isSelected ? 2 : 0;
 
   return (
@@ -92,18 +85,16 @@ function CustomTooltip({
   if (!active || !payload?.length) return null;
 
   const point = payload[0]?.payload;
-  if (!point) return null;
+  if (!point?.san) return null;
 
-  const color = getPointColor(point.category);
+  const color = getPointColor(point.tone);
 
   return (
     <div className="rounded border bg-background p-2 text-sm shadow-md">
       <div className="font-medium" style={{ color }}>
-        {point.san ?? `Ply ${point.ply}`}
+        {point.san}
       </div>
-      {point.category && (
-        <div className="capitalize text-muted-foreground">{point.category}</div>
-      )}
+      {point.label && <div className="text-muted-foreground">{point.label}</div>}
       {point.score && (
         <div className="font-mono text-xs text-muted-foreground">{point.score}</div>
       )}

--- a/libs/ui/src/charts/tests/evaluation-chart.test.tsx
+++ b/libs/ui/src/charts/tests/evaluation-chart.test.tsx
@@ -7,7 +7,10 @@ import { EvaluationChart } from "../evaluation-chart.tsx";
 it("is named by its title", () => {
   const { getByRole } = render(
     <EvaluationChart
-      data={[0.4, 0.6]}
+      data={[
+        { ply: 1, value: 0.4 },
+        { ply: 2, value: 0.6 },
+      ]}
       domain={[0, 1]}
       title="Evaluation over the game"
     />,
@@ -18,9 +21,17 @@ it("is named by its title", () => {
 
 it("renders a line chart with dots", () => {
   const { container } = render(
-    <EvaluationChart data={[0.4, 0.6, 0.5]} domain={[0, 1]} title="Evaluation" />,
+    <EvaluationChart
+      data={[
+        { ply: 1, value: 0.4 },
+        { ply: 2, value: 0.6 },
+        { ply: 3, value: 0.5 },
+      ]}
+      domain={[0, 1]}
+      title="Evaluation"
+    />,
   );
 
   expect(container.querySelector(".recharts-line-curve")).not.toBeNull();
-  expect(container.querySelectorAll(".recharts-line-dot")).toHaveLength(3);
+  expect(container.querySelectorAll("circle")).toHaveLength(3);
 });


### PR DESCRIPTION
## What

Improve the evaluation graph to reflect move categories and connect it to game replay navigation.

## Why

The evaluation graph currently uses a single color, loses move categories, renders identical dots for every ply, and is not connected to game replay. This makes it harder to identify mistakes and navigate the analysis directly from the graph.

## Changes

### `libs/ui/src/charts/evaluation-chart.tsx`
- New `EvaluationPoint` type with `ply`, `value`, `category?`, `san?`, `score?`
- Custom dot renderer: dots colored by category token (`--move-ok`, `--move-inaccuracy`, `--move-mistake`, `--move-blunder`)
- Unanalyzed plies render small dots in the primary color (no category)
- Selected ply gets a larger dot with white stroke highlight
- Recharts tooltip shows SAN, category, and evaluation score
- Dots are clickable (`onSelectPly`) and keyboard-accessible (`tabIndex`, Enter/Space)

### `apps/web/src/games/analysis-read.ts`
- `EvalPoint` now carries `san` and `evalAfter` alongside `category`, so the graph has tooltip data

### `apps/web/src/games/view-analysis/eval-graph.tsx`
- Accepts `selectedPly` and `onSelectPly` props
- Builds `EvaluationPoint[]` with SAN and score strings for tooltips

### `apps/web/src/games/open-game/analysis-panel.tsx`
- Passes `replay.ply` and `replay.goTo` down to `EvalGraph`

### `libs/ui/src/charts/tests/evaluation-chart.test.tsx`
- Updated for new `EvaluationPoint[]` data shape and custom dot rendering

## Screenshots

**Default state** — evaluation curve with category-colored dots:
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/295f4a81-ef5f-4995-a42f-859c58fea148" />


**After clicking a dot** — replays that ply, highlights selected dot, updates board + move list + insight:

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/90ceafb4-aa60-4c3d-a6c9-3e6de00cfe40" />


## Verification

- `pnpm typecheck` ✓
- `pnpm test` ✓ (324 web tests, 55 ui tests)
- `pnpm lint` ✓ (0 errors)
- `pnpm architecture` ✓ (no dependency violations)
- `pnpm build` ✓