### PR TITLE
build(repo): allow the deps-dev commit scope

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -34,6 +34,7 @@ const scopes = [
   "docs",
   "ci",
   "deps",
+  "deps-dev", // Dependabot's scope for devDependencies
   "repo", // tooling and config that belongs to no package
 ];
 


### PR DESCRIPTION
Dependabot scopes devDependency bumps as `build(deps-dev)`, which the commitlint scope enum rejected. Four open Dependabot PRs (#48, #50, #53, #55) fail the commit message check for this reason alone.

Adds `deps-dev` to the scope list. After this merges, those PRs need a rebase to pick up the config.