### PR TITLE
build: move the site screenshot capture to the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ dist/
 .next/
 .turbo/
 apps/site/out/
-apps/web/.playwright/
+.playwright/
 apps/site/.lighthouseci/
 apps/site/src/locales/*/messages.ts
 

--- a/apps/site/AGENTS.md
+++ b/apps/site/AGENTS.md
@@ -21,7 +21,7 @@ changing its structure or rendering model.
 - User-facing copy uses Lingui. Run
   `pnpm --filter @velachess/site i18n:extract` after changing it.
 - Product screenshots come from the deterministic capture flow in
-  `apps/web/e2e/marketing`; do not replace them with hand-made fixture
+  `e2e/capture/` at the repository root; do not replace them with hand-made fixture
   state in this app.
 
 ## Verification

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "capture:site": "playwright test --config playwright.config.ts --project marketing",
     "dev": "vite dev",
     "i18n:extract": "lingui extract --clean",
     "start": "vite preview",
@@ -34,7 +33,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
-    "@playwright/test": "1.62.1",
     "@velachess/server": "workspace:*",
     "@lingui/babel-plugin-lingui-macro": "^6.6.0",
     "@lingui/cli": "^6.6.0",

--- a/docs/explanation/apps/site.md
+++ b/docs/explanation/apps/site.md
@@ -25,7 +25,7 @@ already had the correct owner, while TanStack navigation and product
 screens remain framework-specific.
 
 The screenshots are produced from deterministic fixtures inside the real
-`apps/web` game-analysis and drill slices. `apps/web/e2e/marketing`
+`apps/web` game-analysis and drill slices. `e2e/capture/` at the repository root
 uses Playwright's own `webServer`, routing, viewport and screenshot APIs;
 `pnpm site:capture` writes only the final WebP files into
 `apps/site/public/product`.

--- a/e2e/capture/drill.spec.ts
+++ b/e2e/capture/drill.spec.ts
@@ -1,13 +1,13 @@
 import path from "node:path";
 
-import { expect, settle, test } from "./marketing.fixture.ts";
+import { expect, settle, test } from "./staged-product.fixture.ts";
 
 const output = path.resolve(
   import.meta.dirname,
-  "../../../site/public/product/drill.webp",
+  "../../apps/site/public/product/drill.webp",
 );
 
-test("captures the drill feedback loop", async ({ marketingPage: page }) => {
+test("captures the drill feedback loop", async ({ productPage: page }) => {
   await page.goto("/drill");
   await page.getByRole("button", { name: "Start drilling" }).click();
 

--- a/e2e/capture/game-analysis.spec.ts
+++ b/e2e/capture/game-analysis.spec.ts
@@ -1,14 +1,14 @@
 import path from "node:path";
 
-import { LANDING_GAME_ID } from "../../src/games/open-game/tests/fixtures/landing-game-analysis.ts";
-import { expect, settle, test } from "./marketing.fixture.ts";
+import { LANDING_GAME_ID } from "../../apps/web/src/games/open-game/tests/fixtures/landing-game-analysis.ts";
+import { expect, settle, test } from "./staged-product.fixture.ts";
 
 const output = path.resolve(
   import.meta.dirname,
-  "../../../site/public/product/game-analysis.webp",
+  "../../apps/site/public/product/game-analysis.webp",
 );
 
-test("captures the game analysis blunder", async ({ marketingPage: page }) => {
+test("captures the game analysis blunder", async ({ productPage: page }) => {
   await page.goto(`/games/${LANDING_GAME_ID}`);
 
   const blunder = page.getByRole("button", { name: /g4.*\?\?/ });

--- a/e2e/capture/staged-product.fixture.ts
+++ b/e2e/capture/staged-product.fixture.ts
@@ -4,13 +4,13 @@ import {
   landingDrill,
   landingDrillAnswer,
   landingDrillQueue,
-} from "../../src/drill/tests/fixtures/landing-drill.ts";
+} from "../../apps/web/src/drill/tests/fixtures/landing-drill.ts";
 import {
   LANDING_GAME_ID,
   LANDING_PLAYER,
   landingCompletedAnalysis,
   landingGame,
-} from "../../src/games/open-game/tests/fixtures/landing-game-analysis.ts";
+} from "../../apps/web/src/games/open-game/tests/fixtures/landing-game-analysis.ts";
 
 const FIXED_NOW = "2026-08-21T12:00:00.000Z";
 
@@ -90,7 +90,7 @@ async function handleApi(route: Route) {
     return;
   }
 
-  throw new Error(`Unexpected marketing capture request: ${method} ${pathname}`);
+  throw new Error(`Unexpected capture request: ${method} ${pathname}`);
 }
 
 async function preparePage(page: Page) {
@@ -122,8 +122,8 @@ async function settle(page: Page) {
   });
 }
 
-export const test = base.extend<{ marketingPage: Page }>({
-  marketingPage: async ({ page }, use) => {
+export const test = base.extend<{ productPage: Page }>({
+  productPage: async ({ page }, use) => {
     const errors: string[] = [];
     page.on("console", (message) => {
       if (message.type() === "error") errors.push(message.text());

--- a/knip.json
+++ b/knip.json
@@ -17,13 +17,8 @@
     // filesystem rather than through an import, so knip has to be told the
     // same thing the plugin already knows.
     "apps/web": {
-      "entry": [
-        "src/routes/**/*.tsx",
-        "lingui.config.ts",
-        "**/*.test.{ts,tsx}",
-        "**/*.spec.{ts,tsx}"
-      ],
-      "project": ["src/**/*.{ts,tsx,css}", "e2e/**/*.{ts,tsx}"]
+      "entry": ["src/routes/**/*.tsx", "lingui.config.ts", "**/*.test.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx,css}"]
     },
     "apps/site": {
       "entry": [

--- a/package.json
+++ b/package.json
@@ -38,13 +38,14 @@
     "test": "turbo run test test:root",
     "test:watch": "vitest",
     "e2e": "vitest run --project e2e",
-    "site:capture": "pnpm --filter @velachess/web capture:site",
+    "site:capture": "playwright test --project site-capture",
     "site:lighthouse": "pnpm --filter @velachess/site lighthouse",
     "site:quality": "pnpm --filter @velachess/site build && pnpm --filter @velachess/site test && pnpm site:lighthouse"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
+    "@playwright/test": "1.62.1",
     "@types/node": "^26.2.0",
     "dependency-cruiser": "^18.2.0",
     "jsdom": "^30.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: "./e2e/marketing",
+  testDir: "./e2e/capture",
   outputDir: "./.playwright/test-results",
   fullyParallel: false,
   workers: 1,
@@ -17,14 +17,14 @@ export default defineConfig({
     viewport: { width: 1440, height: 900 },
   },
   webServer: {
-    command: "pnpm dev --host 127.0.0.1 --port 4173",
+    command: "pnpm --filter @velachess/web dev --host 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173",
     reuseExistingServer: false,
     timeout: 120_000,
   },
   projects: [
     {
-      name: "marketing",
+      name: "site-capture",
       use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } },
     },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^21.2.2
         version: 21.2.2
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -242,9 +245,6 @@ importers:
       '@lingui/vite-plugin':
         specifier: ^6.6.0
         version: 6.6.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8))(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@playwright/test':
-        specifier: 1.62.1
-        version: 1.62.1
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
         test: {
           ...backendTest,
           name: "e2e",
-          include: ["e2e/**/*.spec.ts"],
+          // `e2e/capture/` is Playwright, not Vitest: it stays out of this project.
+          include: ["e2e/*.spec.ts"],
         },
         resolve: { alias: aliases },
       },


### PR DESCRIPTION
## What

Moves the Playwright screenshot capture from `apps/web/e2e/marketing` to `e2e/capture/` at the repository root, with the Playwright config and `@playwright/test` at the root.

- `marketing.fixture.ts` → `staged-product.fixture.ts` (fixture `marketingPage` → `productPage`): a staged session, fixed clock, tracked account, a drill and an analysed game, served by `page.route` over the real `apps/web` screens.
- Playwright project `marketing` → `site-capture`. `pnpm site:capture` keeps its name; `apps/web` loses `capture:site`.
- Root Vitest `e2e` project narrows to `e2e/*.spec.ts` so it does not pick up the Playwright specs (this is what `docs/how-to/verify-a-change.md` already said it ran).
- `apps/web` knip entry `**/*.spec.ts` removed: it matched nothing after the move.
- Docs updated: `docs/explanation/apps/site.md`, `apps/site/AGENTS.md`.

## Why

The flow is cross-app: it runs `apps/web`, imports its product fixtures, and writes files into `apps/site/public`. Under `apps/web/e2e/` it read as a web acceptance suite (there is none), named after its consumer. `e2e/` at the root is where the repo already keeps flows owned by neither app.

## Verification

- `pnpm check` (typecheck + lint + architecture + knip): pass
- `pnpm fmt:check`: pass
- `pnpm test`: 18/18 tasks pass
- `pnpm e2e`: 2/2 pass
- `pnpm site:capture`: 2/2 pass, writes `apps/site/public/product/{drill,game-analysis}.webp`
- `pnpm install --frozen-lockfile`: "Lockfile is up to date" (the local Node 24.2.0 then trips jsdom's engine range, unrelated to this change)

## Evidence

- Regenerated screenshots are not committed here: `site:capture` on `main` already produces images that differ from the committed ones (#44 and #62 changed those screens). That refresh is a separate change.

## Checklist

- [ ] Tests added or updated
- [x] Relevant evidence included
- [ ] Migrations verified, if applicable
- [x] Documentation updated, if applicable
