### PR TITLE
fix(ui): stop the move-grade badge clipping on edge squares

### DIFF
--- a/libs/ui/src/chess/board-theme.ts
+++ b/libs/ui/src/chess/board-theme.ts
@@ -92,6 +92,15 @@ export const BOARD_STYLE = {
   light: { backgroundColor: cssVar(TOKEN.lightSquare) },
   dark: { backgroundColor: cssVar(TOKEN.darkSquare) },
   highlight: { backgroundColor: cssVar(TOKEN.highlight) },
+  /**
+   * The library's own board root defaults to `overflow: hidden`. A
+   * `SquareBadge` deliberately sits a few pixels past its square's corner
+   * (see square-badge.tsx), which an interior square's neighbour absorbs —
+   * but on an edge square that overflow crosses the board root itself and
+   * gets clipped. The drag ghost is unaffected: it renders through
+   * `@dnd-kit`'s `DragOverlay`, a portal outside this element entirely.
+   */
+  frame: { overflow: "visible" },
 } as const satisfies Record<string, React.CSSProperties>;
 
 /**

--- a/libs/ui/src/chess/board.tsx
+++ b/libs/ui/src/chess/board.tsx
@@ -260,6 +260,9 @@ export function Board({
           showAnimations: animated,
           animationDurationInMs: ANIMATION_DURATION_MS,
           allowDragging: interactive && onMove !== undefined,
+          // Lets a badge on an edge square draw in full instead of being
+          // clipped by the library's own board root (BOARD_STYLE.frame).
+          boardStyle: BOARD_STYLE.frame,
           lightSquareStyle: BOARD_STYLE.light,
           darkSquareStyle: BOARD_STYLE.dark,
           // The last move still goes here: it is painted before any

--- a/libs/ui/src/chess/tests/board-render.test.tsx
+++ b/libs/ui/src/chess/tests/board-render.test.tsx
@@ -63,3 +63,22 @@ it("renders a square for every one of the sixty-four", () => {
 
   expect(container.querySelectorAll("[data-square]")).toHaveLength(64);
 });
+
+/**
+ * A badge on a corner square (#64). `board.test.tsx` pins that we ask
+ * `react-chessboard` for `boardStyle: { overflow: "visible" }`; this is the
+ * guard that the real library actually applies it to its own board root
+ * rather than to some other element, which is exactly the class of bug
+ * `board-render.test.tsx` exists to catch.
+ */
+it("leaves the board root unclipped so a badge on a corner square draws in full", () => {
+  const { container } = render(
+    <Board fen={START} badges={{ h1: { tone: "blunder", label: "??" } }} />,
+  );
+
+  const boardRoot = container.querySelector("#chessboard-board") as HTMLElement | null;
+  expect(boardRoot).not.toBeNull();
+  expect(boardRoot?.style.overflow).toBe("visible");
+
+  expect(squareAt(container, "h1")?.textContent).toContain("??");
+});

--- a/libs/ui/src/chess/tests/board.test.tsx
+++ b/libs/ui/src/chess/tests/board.test.tsx
@@ -26,6 +26,7 @@ interface CapturedOptions {
   position: string;
   boardOrientation: string;
   allowDragging: boolean;
+  boardStyle: { overflow?: string };
   showAnimations: boolean;
   animationDurationInMs: number;
   showNotation: boolean;
@@ -150,6 +151,11 @@ it("animates by default and holds still on request", () => {
 
   render(<Board fen={START} animated={false} />);
   expect(captured.showAnimations).toBe(false);
+});
+
+it("asks the library for an unclipped board root, so a badge on an edge square is not cut off", () => {
+  render(<Board fen={START} />);
+  expect(captured.boardStyle).toEqual({ overflow: "visible" });
 });
 
 it("is not draggable without an onMove handler", () => {


### PR DESCRIPTION
## Summary
`react-chessboard`'s board root defaults to `overflow: hidden`. `SquareBadge` deliberately sits a few pixels past its square's corner (`-top-1 -right-1`) so it reads as attached rather than inset — an interior square's neighbour silently absorbs that overflow, but on the h-file, a-file, 1st rank or 8th rank it crosses the board root itself and gets clipped.

Went with the fix suggested in the issue: `boardStyle: { overflow: "visible" }`, passed through the `options` the wrapper already hands `react-chessboard` (added as `BOARD_STYLE.frame` in `board-theme.ts`, next to the other themed styles, rather than a literal in `board.tsx`).

On the drag-ghost concern raised in the issue: read the compiled library source (`react-chessboard` 5.12.1) rather than assuming — the dragged piece renders through `@dnd-kit`'s `DragOverlay`, which portals outside this element entirely, so it was never affected by the board root's own overflow either way.

Closes #64

## Test plan
- [x] `board.test.tsx` (mocked library) — new assertion that `boardStyle: { overflow: "visible" }` is what we ask the library for
- [x] `board-render.test.tsx` (real, unmocked library, per this repo's own two-seam testing doc) — new test rendering a badge on `h1` (a corner square) and asserting the real board root (`#chessboard-board`) actually received `overflow: visible`, plus that the badge itself is present
- [x] `cd libs/ui && npx vitest run` — 8 files, 57 tests, all passing
- [x] `npx tsc --noEmit` at the repo root — clean
- [x] `npx oxlint` / `npx oxfmt --check` on the four changed files — clean
- [ ] `pnpm typecheck` (the turbo-orchestrated gate) — **could not run**: `turbo.exe` is blocked by a Windows Application Control policy in my sandbox (confirmed via the actual PowerShell error, not a guess). Pushed with `LEFTHOOK=0`, which `docs/how-to/verify-a-change.md` documents as the sanctioned way to skip the hooks "when you mean to" — flagging this honestly since I couldn't run the exact gate CI will run, though the direct `tsc --noEmit` above covers the same check turbo would have dispatched.