### PR TITLE
Fix move grade badge glyph

### DIFF
--- a/apps/web/src/games/analysis-read.ts
+++ b/apps/web/src/games/analysis-read.ts
@@ -144,12 +144,18 @@ const CATEGORY_BADGE: Partial<Record<MoveCategory, BadgeTone>> = {
 
 const BEST_MOVE_GLYPH = "✓";
 
-export function badgeForCategory(
-  category: MoveCategory,
-): { tone: BadgeTone; label: string } | null {
+export interface CategoryBadge {
+  tone: BadgeTone;
+  /** Raw NAG text, or `BEST_MOVE_GLYPH` for the best move — notation, not
+   * a ready-to-render label. The board renders this as an SVG mark rather
+   * than the glyph itself; see `BadgeGlyph` in `@velachess/ui`. */
+  glyph: string;
+}
+
+export function badgeForCategory(category: MoveCategory): CategoryBadge | null {
   const tone = CATEGORY_BADGE[category];
   if (!tone) return null;
-  return { tone, label: glyphOf(category) ?? BEST_MOVE_GLYPH };
+  return { tone, glyph: glyphOf(category) ?? BEST_MOVE_GLYPH };
 }
 
 /** Translated category names for UI display. */

--- a/apps/web/src/games/open-game/board-pane.tsx
+++ b/apps/web/src/games/open-game/board-pane.tsx
@@ -1,6 +1,7 @@
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 
+import { BadgeGlyph } from "@velachess/ui/chess/badge-glyph";
 import { Board } from "@velachess/ui/chess/board";
 import type { SquareBadgeSpec } from "@velachess/ui/chess/board";
 import {
@@ -165,5 +166,14 @@ function badgesFor(
 ): Record<string, SquareBadgeSpec> | undefined {
   if (!square || !grade) return undefined;
   const badge = badgeForCategory(grade.category);
-  return badge ? { [square]: badge } : undefined;
+  if (!badge) return undefined;
+
+  const label =
+    badge.tone === "ok" ? (
+      <BadgeGlyph kind="best" />
+    ) : (
+      <BadgeGlyph kind="nag" nag={badge.glyph} />
+    );
+
+  return { [square]: { tone: badge.tone, label } };
 }

--- a/apps/web/src/games/tests/analysis-read.test.ts
+++ b/apps/web/src/games/tests/analysis-read.test.ts
@@ -199,11 +199,11 @@ describe("bestMoveSan", () => {
 
 describe("badgeForCategory", () => {
   it("marks the moves worth stopping on", () => {
-    expect(badgeForCategory("blunder")).toEqual({ tone: "blunder", label: "??" });
-    expect(badgeForCategory("mistake")).toEqual({ tone: "mistake", label: "?" });
+    expect(badgeForCategory("blunder")).toEqual({ tone: "blunder", glyph: "??" });
+    expect(badgeForCategory("mistake")).toEqual({ tone: "mistake", glyph: "?" });
     expect(badgeForCategory("inaccuracy")).toEqual({
       tone: "inaccuracy",
-      label: "?!",
+      glyph: "?!",
     });
     expect(badgeForCategory("best")?.tone).toBe("ok");
   });

--- a/libs/ui/src/chess/badge-glyph.tsx
+++ b/libs/ui/src/chess/badge-glyph.tsx
@@ -1,0 +1,68 @@
+/**
+ * [UI] The mark inside a `SquareBadge`: a checkmark for the best move, or a
+ * NAG punctuation mark (`?!`, `?`, `??`) for a grade. Both render as SVG
+ * with a fixed stroke, the same fix `PieceIcon` applies to pieces — a
+ * Unicode glyph's weight is decided by whatever font the reader's platform
+ * substitutes, which is what made the old badge read as thin on some
+ * screens and heavier on others.
+ */
+
+import { CheckIcon } from "lucide-react";
+
+import { cn } from "../lib/utils.ts";
+
+export type BadgeGlyphKind = "best" | "nag";
+
+export interface BadgeGlyphProps {
+  kind: BadgeGlyphKind;
+  /** NAG text (`?!`, `?`, `??`). Required when `kind` is `"nag"`, ignored
+   * otherwise — notation, not copy, so this package does not translate it. */
+  nag?: string;
+  className?: string;
+}
+
+/** A checkmark's stroke sits low-left of its bounding box; nudge it down
+ * and right so it optically centres inside the circle instead of just
+ * centring by the box model. */
+const CHECK_NUDGE = "translate-x-[4%] translate-y-[6%]";
+
+/** `??` is two glyphs wide, so it needs a smaller size than `?` to keep
+ * every NAG mark reading at roughly the same visual weight. */
+const NAG_FONT_SIZE: Record<number, number> = { 1: 15, 2: 11 };
+const NAG_FONT_SIZE_FALLBACK = 10;
+
+export function BadgeGlyph({ kind, nag, className }: BadgeGlyphProps) {
+  if (kind === "best") {
+    return (
+      <CheckIcon
+        aria-hidden
+        className={cn("size-[62%] stroke-[3.5]", CHECK_NUDGE, className)}
+      />
+    );
+  }
+
+  const text = nag ?? "";
+  const fontSize = NAG_FONT_SIZE[text.length] ?? NAG_FONT_SIZE_FALLBACK;
+
+  return (
+    <svg aria-hidden viewBox="0 0 24 24" className={cn("size-[80%]", className)}>
+      <text
+        x="50%"
+        y="53%"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={fontSize}
+        fontWeight={700}
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth={0.5}
+        paintOrder="stroke"
+      >
+        {text}
+      </text>
+    </svg>
+  );
+}
+  );
+}</text>

--- a/libs/ui/src/chess/badge-glyph.tsx
+++ b/libs/ui/src/chess/badge-glyph.tsx
@@ -64,5 +64,3 @@ export function BadgeGlyph({ kind, nag, className }: BadgeGlyphProps) {
     </svg>
   );
 }
-  );
-}</text>

--- a/libs/ui/src/chess/square-badge.tsx
+++ b/libs/ui/src/chess/square-badge.tsx
@@ -24,12 +24,13 @@ export function SquareBadge({ tone, children }: SquareBadgeProps) {
       aria-hidden
       // Nudged past the corner so it reads as attached to the square
       // rather than sitting inside it, which is where every board in the
-      // benchmark puts it. `ring` in the board's own colour keeps it
-      // legible against a piece underneath.
+      // benchmark puts it. A soft shadow gives it separation from the
+      // square underneath without the flat grey rim a fixed-colour ring
+      // produced regardless of the badge's own fill.
       className={cn(
         "pointer-events-none absolute -top-1 -right-1 z-10 grid size-[42%]",
-        "place-items-center rounded-full text-[0.6rem] leading-none font-medium",
-        "ring-2 ring-(--board-light)",
+        "place-items-center rounded-full leading-none",
+        "shadow-[0_1px_3px_rgba(15,23,42,0.45)]",
         LIGHT_ON_TONE.has(tone) ? "text-white" : "text-black/80",
       )}
       style={{ backgroundColor: BADGE_TONE_COLOR[tone] }}

--- a/libs/ui/src/chess/tests/badge-glyph.test.tsx
+++ b/libs/ui/src/chess/tests/badge-glyph.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+/**
+ * The board's move-grade mark: an SVG, not a Unicode glyph — same fix
+ * `piece-icon.test.tsx` pins for pieces, and for the same reason (a
+ * Unicode glyph's stroke weight is decided by the reader's platform font).
+ */
+import { render } from "@testing-library/react";
+import { expect, it } from "vitest";
+
+import { BadgeGlyph } from "../badge-glyph.tsx";
+
+it("draws the best-move mark as an svg, not a font glyph", () => {
+  const { container } = render(<BadgeGlyph kind="best" />);
+  expect(container.querySelector("svg")).not.toBeNull();
+});
+
+it("draws a NAG mark as an svg carrying its own text", () => {
+  const { container } = render(<BadgeGlyph kind="nag" nag="??" />);
+  const svg = container.querySelector("svg");
+  expect(svg).not.toBeNull();
+  expect(svg?.textContent).toBe("??");
+});
+
+it("is decorative — the badge's tone already carries the meaning", () => {
+  const { container } = render(<BadgeGlyph kind="best" />);
+  expect(container.firstElementChild?.getAttribute("aria-hidden")).toBe("true");
+});


### PR DESCRIPTION
## What

Fixes #77. The move-grade badge on the board (best-move check, and the `?!`/`?`/`??` NAG marks for inaccuracy/mistake/blunder) rendered its mark as a Unicode glyph. This replaces it with an SVG mark via a new `BadgeGlyph` component in `@velachess/ui`, and swaps the badge's separation styling from a fixed-color ring to a soft shadow, matching the issue description.

## Why

A Unicode glyph's stroke weight is decided by whatever font the reader's platform substitutes, so the badge read as thin on some systems and heavier on others. `libs/ui/src/chess/piece-icon.tsx` already solves the same problem for chess pieces by rendering an SVG instead of a glyph; this applies the same fix to the move-grade badge.

## How

- Added `libs/ui/src/chess/badge-glyph.tsx`: a `BadgeGlyph` component that renders a `CheckIcon` (lucide-react) for the best move, or an inline SVG `<text>` mark for a NAG string, with `fill` and `stroke` both set to `currentColor` so the mark's weight is consistent across platforms.
- `libs/ui/src/chess/square-badge.tsx`: removed the `ring-2 ring-(--board-light)` styling and the now-unneeded text-size classes (children are icons, not text), replaced with a soft `shadow-[...]` for separation from the square underneath.
- `apps/web/src/games/analysis-read.ts`: renamed `badgeForCategory`'s return field from `label` to `glyph` (raw NAG text / best-move marker), and gave it a named exported type `CategoryBadge` instead of an inline type, since the field is now notation to be rendered by `BadgeGlyph` rather than a ready label.
- `apps/web/src/games/open-game/board-pane.tsx`: `badgesFor` now builds the `SquareBadgeSpec.label` as a `<BadgeGlyph kind="best" />` or `<BadgeGlyph kind="nag" nag={badge.glyph} />` element (`SquareBadgeSpec.label` is already typed `ReactNode`, so this needed no type change there).
- Updated the existing `badgeForCategory` unit tests for the `label` → `glyph` rename, and added `libs/ui/src/chess/tests/badge-glyph.test.tsx` following the same pattern as `piece-icon.test.tsx`.
`apps/web/src/games/open-game/move-list.tsx` also calls a `glyphOf()` helper in this file, but renders it as plain text in a different context (the move list, not a board badge) — that usage is unrelated to this issue and was intentionally left unchanged.

## Verification

I wasn't able to run `pnpm check` / `pnpm test` in the environment I used to prepare this change (no registry access there), so this has **not** been verified by the automated test suite yet. What I did do:

- Manually traced every call site of `badgeForCategory`, `CategoryBadge`, and `SquareBadgeSpec.label` to confirm the rename and the new component don't break anything outside this diff.
- Updated the pre-existing `badgeForCategory` tests for the field rename, and added new tests for `BadgeGlyph` mirroring `piece-icon.test.tsx`'s coverage (renders an svg for both kinds, NAG text is carried into the svg, and the mark is `aria-hidden`).
- Checked the change against this repo's `AGENTS.md`/`CLAUDE.md` conventions (arbitrary Tailwind values allowed in `libs/ui` but not `apps/web`, no literal user-facing copy — NAG marks are notation and exempted, `SquareBadgeSpec.label: ReactNode`).
Could someone confirm CI is green on this one? Happy to fix anything that comes up.

## Evidence

N/A — no visible runtime behavior change beyond the badge's own rendering, covered by the tests above.

## Checklist

- [x] Tests added or updated
- [ ] Relevant evidence included
- [ ] Migrations verified, if applicable
- [ ] Documentation updated, if applicable